### PR TITLE
fix(ci): repair schema diff + CI diff-accuracy (docs-only no-op, test-gate decoupling) (#53)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,9 +114,16 @@ jobs:
         if: ${{ steps.dbt_build.outcome == 'success' }}
         run: bash scripts/pr_data_diff.sh
 
+      # continue-on-error keeps a schema-diff failure from failing the build, but
+      # it does not bound runtime, and GitHub applies no per-step timeout (the
+      # job-level 360-minute default would otherwise apply). The downstream
+      # publish steps gate on this step's outcome so a partial report is never
+      # posted as if it were complete.
       - name: Generate schema diffs for changed models
+        id: schema_diff
         if: ${{ steps.dbt_build.outcome == 'success' }}
         continue-on-error: true
+        timeout-minutes: 10
         run: bash scripts/pr_schema_diff.sh
 
       - name: Upload CI artifacts (docs + manifest + data diffs)
@@ -153,7 +160,7 @@ jobs:
           path: diff_reports/
 
       - name: Attach schema diffs to PR as artifact
-        if: ${{ steps.dbt_build.outcome == 'success' && hashFiles('schema_diff_reports/**') != '' }}
+        if: ${{ steps.schema_diff.outcome == 'success' && hashFiles('schema_diff_reports/**') != '' }}
         uses: actions/upload-artifact@v4
         with:
           name: schema-diff-pr-${{ github.event.number }}-${{ github.run_id }}
@@ -183,7 +190,7 @@ jobs:
             await github.rest.issues.createComment({ owner, repo, issue_number, body: fullBody });
 
       - name: Post schema summary comment on PR
-        if: ${{ steps.dbt_build.outcome == 'success' && hashFiles('schema_diff_reports/schema-summary.md') != '' && github.event.pull_request.head.repo.full_name == github.repository }}
+        if: ${{ steps.schema_diff.outcome == 'success' && hashFiles('schema_diff_reports/schema-summary.md') != '' && github.event.pull_request.head.repo.full_name == github.repository }}
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,12 +54,7 @@ jobs:
 
       - name: Detect changed dbt files
         id: changes
-        run: |
-          bash scripts/get_changed_models.sh | tee /tmp/get_changed_models.out
-          # Only forward genuine KEY=VALUE lines to $GITHUB_ENV — the script's
-          # log output (headers, indented file lists) is not env-file-safe and
-          # would otherwise corrupt the file / fail the step.
-          grep -E '^[A-Za-z_][A-Za-z0-9_]*=' /tmp/get_changed_models.out >> "$GITHUB_ENV"
+        run: bash scripts/get_changed_models.sh
 
       - id: auth
         uses: google-github-actions/auth@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,8 +104,13 @@ jobs:
         id: dbt_test
         if: ${{ steps.dbt_build.outcome == 'success' && env.HAS_MODEL_CHANGES != 'false' }}
         continue-on-error: true
+        # --indirect-selection cautious: under --defer, a data test spanning a
+        # freshly-built (selected) model and a deferred (stale-prod) model would
+        # reconcile fresh-vs-stale and fail on non-code drift. cautious runs a
+        # test only when every referenced model is selected, keeping those false
+        # errors out of the report (they still run in the full nightly/prod build).
         run: |
-          dbt test --target ci ${CI_SELECT:+--select "$CI_SELECT"} ${CI_DEFER}
+          dbt test --target ci --indirect-selection cautious ${CI_SELECT:+--select "$CI_SELECT"} ${CI_DEFER}
 
       - name: Source freshness (optional)
         if: ${{ steps.dbt_build.outcome == 'success' && env.RUN_FRESHNESS == 'true' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+      - name: Test shell scripts
+        run: bash tests/test_pr_schema_diff.sh
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
@@ -114,6 +116,7 @@ jobs:
 
       - name: Generate schema diffs for changed models
         if: ${{ steps.dbt_build.outcome == 'success' }}
+        continue-on-error: true
         run: bash scripts/pr_schema_diff.sh
 
       - name: Upload CI artifacts (docs + manifest + data diffs)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
         run: |
           bash tests/test_pr_schema_diff.sh
           bash tests/test_pr_data_diff.sh
+          bash tests/test_get_changed_models.sh
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,9 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Test shell scripts
-        run: bash tests/test_pr_schema_diff.sh
+        run: |
+          bash tests/test_pr_schema_diff.sh
+          bash tests/test_pr_data_diff.sh
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
@@ -52,7 +54,12 @@ jobs:
 
       - name: Detect changed dbt files
         id: changes
-        run: bash scripts/get_changed_models.sh
+        run: |
+          bash scripts/get_changed_models.sh | tee /tmp/get_changed_models.out
+          # Only forward genuine KEY=VALUE lines to $GITHUB_ENV — the script's
+          # log output (headers, indented file lists) is not env-file-safe and
+          # would otherwise corrupt the file / fail the step.
+          grep -E '^[A-Za-z_][A-Za-z0-9_]*=' /tmp/get_changed_models.out >> "$GITHUB_ENV"
 
       - id: auth
         uses: google-github-actions/auth@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
           bash tests/test_pr_schema_diff.sh
           bash tests/test_pr_data_diff.sh
           bash tests/test_get_changed_models.sh
+          bash tests/test_ci_build.sh
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
@@ -98,6 +99,13 @@ jobs:
       - name: Slim CI build (with defer if prod manifest exists)
         id: dbt_build
         run: bash scripts/ci_build.sh
+
+      - name: Run dbt tests (non-blocking; does not gate diffs)
+        id: dbt_test
+        if: ${{ steps.dbt_build.outcome == 'success' && env.HAS_MODEL_CHANGES != 'false' }}
+        continue-on-error: true
+        run: |
+          dbt test --target ci ${CI_SELECT:+--select "$CI_SELECT"} ${CI_DEFER}
 
       - name: Source freshness (optional)
         if: ${{ steps.dbt_build.outcome == 'success' && env.RUN_FRESHNESS == 'true' }}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: init deps build test lint lint-fix docs compare clean freshness
+.PHONY: init deps build test test-scripts lint lint-fix docs compare clean freshness
 
 # One-time setup: load env vars, install deps, install pre-commit
 init:
@@ -19,6 +19,10 @@ run:
 
 test:
 	dbt test --target $${DBT_TARGET:-dev}
+
+# Shell script tests. No warehouse connection, no credentials, no cost.
+test-scripts:
+	bash tests/test_pr_schema_diff.sh
 
 lint:
 	pre-commit run --hook-stage manual --all-files

--- a/docs/ci-slim-build-diff-learnings.md
+++ b/docs/ci-slim-build-diff-learnings.md
@@ -1,0 +1,110 @@
+# CI Slim-Build Diff & Test Accuracy — Learnings
+
+A single reference for how the template's PR CI produces **data diffs** and **schema diffs**,
+why "no-op" PRs can show phantom differences or false test failures, and how the template's
+design mitigates each. Distilled from the multi-phase effort on this template (PRs #55, #56) and
+validated end-to-end against a real downstream consumer (`weightcare-pipeline-new`).
+
+## How the check is built
+
+On a PR, CI builds only the changed models and **defers everything else to prod**:
+
+```
+dbt build --select <scope> --defer --state prod_state --exclude-resource-type test
+```
+
+- **Selected** models are rebuilt **fresh** in an ephemeral CI dataset, from **current** sources.
+- **Unselected** ancestors resolve to the **last prod build's tables** (older snapshot).
+
+The data diff then compares each built model (dev, now) against its prod counterpart (built
+earlier). **The two sides are not built from the same source snapshot** — so any difference that
+isn't caused by the PR's code is a *false positive*. The sections below are the classes of false
+positive and how to keep them out of the signal.
+
+## Selection: build scope == diff scope
+
+`scripts/get_changed_models.sh` derives the scope from the **git diff**, emitting:
+
+- `HAS_MODEL_CHANGES` — false for docs/config-only PRs.
+- `DIFF_SELECT` / `BUILD_SELECT` — `name+` per changed model/seed/snapshot (model + downstream;
+  no leading `+`, so ancestors defer). These are **identical**, so build and diff cover the same
+  models.
+- `NEEDS_FALLBACK` — true for macro / `dbt_project.yml` / `packages.yml` / yaml-only changes that
+  can't be scoped by filename.
+
+`scripts/ci_build.sh` consumes these: git-diff-scoped build for model changes; a combined
+`"$BUILD_SELECT state:modified+"` tier when a macro/config change accompanies model changes;
+`state:modified+` for macro/config/yaml-only; and a full build only when no prod manifest exists.
+
+## The false-positive classes (and the fix)
+
+1. **Ancestor rebuild → drift.** If the build selects ancestors too (e.g. `+model+` with a leading
+   `+`), they rebuild from *current* sources while prod used *older* ones → the whole downstream
+   differs. **Fix:** scope to `model+` (no leading `+`) and `--defer` unchanged ancestors to prod,
+   so both sides read the same upstream tables. (This template already does this.)
+
+2. **FLOAT64 non-associativity.** Floating-point `SUM`/aggregation is **not associative**;
+   BigQuery may combine partitions in a different order across builds, so a byte-identical model
+   yields slightly different `FLOAT64` values each run. `EXCEPT DISTINCT` then reports thousands of
+   "changed" rows for a no-op (observed: ~11k phantom rows in a monthly-aggregation model).
+   **Fix (in the models):** round/quantize `FLOAT64` columns before they're compared
+   (e.g. `ROUND(x, 6)`), or store money as `NUMERIC`. This is a **data-modeling** fix in the
+   consumer's models, not a CI change.
+
+3. **Non-deterministic row selection (`ROW_NUMBER`/`QUALIFY`).** A `QUALIFY ROW_NUMBER() OVER
+   (... ORDER BY <non-unique>) = 1` breaks ties differently across builds → different rows survive
+   → diff noise for a no-op. **Fix (in the models):** add a unique tiebreaker to the `ORDER BY`.
+
+4. **Defer boundary + eager indirect selection.** `--defer` does **not** freeze `source()` reads
+   or **view** (ephemeral/view-materialized) ancestors — those still read live data. And dbt's
+   default **eager** indirect selection runs a data test if **any** referenced model is selected,
+   even when the test also spans a **deferred** (stale) model → it reconciles fresh-vs-stale and
+   fails on non-code drift. **Fix:** run tests with **`--indirect-selection cautious`**, which
+   runs a data test only when **every** model it references is selected. Cross-boundary tests are
+   skipped in PR CI (they still run in the nightly/prod build against one consistent snapshot).
+   Single-model tests (`not_null`/`unique`/`accepted_values`) and both-sides-selected tests still
+   run — it cannot mask a real regression.
+
+## Test gating: don't let a red data test suppress the diff
+
+`ci_build.sh` builds with `--exclude-resource-type test`; `dbt test` runs as a **separate,
+non-blocking** CI step. So a failing data test surfaces as its own (red) check without skipping the
+diff/comment steps (which gate on model-build success only).
+
+> **ACTION ITEM (open):** the non-blocking `dbt test` step must also pass
+> **`--indirect-selection cautious`**. Otherwise the class-4 cross-boundary tests still fill the
+> non-blocking test *report* with false errors and bury real ones. (PR #56 adds this flag to
+> `main`'s inline build; on this branch it belongs on the separate `dbt test` invocation.)
+
+## Docs-only PRs
+
+`HAS_MODEL_CHANGES=false` short-circuits both `pr_data_diff.sh` and `pr_schema_diff.sh` before any
+`bq`/`dbt` call, so a docs-only PR posts no diff. Note: a **scripts/workflow-only** PR is also
+"no model changes" — useful, because it means a CI-infra PR won't try to diff.
+
+## Offline verification tricks
+
+- **Which tests will run:** `dbt ls --select <scope> --indirect-selection eager|cautious
+  --resource-type test` shows exactly which tests each mode includes — deterministic, no BigQuery.
+- **Don't validate with a scripts-only PR.** A PR that changes only `scripts/`/workflow yields
+  `HAS_MODEL_CHANGES=false` → nothing is built/diffed. To exercise the diff, the test PR must touch
+  a **model** (a no-op CTE rename is ideal for the "expect ~0 diff" check).
+- **Workflow trigger:** the CI workflow runs on `pull_request` to `main` only — a PR based on a
+  feature branch won't trigger it (rebase onto `main`, or push a trigger commit).
+
+## Known limitations (accepted)
+
+- **Macro+model PRs: build ⊋ diff.** The build unions `state:modified+` for macro coverage, but the
+  diff uses the git scope only — macro-affected models are built but not diffed.
+- **Fallback path is manifest-dependent.** Model-change PRs are manifest-independent for build
+  scoping; macro/config/yaml-only PRs still use `state:modified+` and can over-select if the prod
+  manifest is stale.
+- **Classes 2 & 3 are data-modeling fixes**, not CI features — the template can't fix a consumer's
+  non-deterministic models; this doc is the guidance.
+
+## Cross-references
+
+- Design/plan: `docs/superpowers/specs/2026-08-12-template-build-selection-parity-design.md`,
+  `docs/superpowers/plans/2026-08-12-template-build-selection-parity.md`.
+- Downstream consolidation (weightcare): `docs/ci_slim_build_accuracy_learnings.md` (that repo's
+  PR #142), covering the same classes with issue-level history (#117, #128–#131, #138, #140).

--- a/docs/ci-slim-build-diff-learnings.md
+++ b/docs/ci-slim-build-diff-learnings.md
@@ -71,10 +71,10 @@ positive and how to keep them out of the signal.
 non-blocking** CI step. So a failing data test surfaces as its own (red) check without skipping the
 diff/comment steps (which gate on model-build success only).
 
-> **ACTION ITEM (open):** the non-blocking `dbt test` step must also pass
-> **`--indirect-selection cautious`**. Otherwise the class-4 cross-boundary tests still fill the
-> non-blocking test *report* with false errors and bury real ones. (PR #56 adds this flag to
-> `main`'s inline build; on this branch it belongs on the separate `dbt test` invocation.)
+> **Resolved:** the non-blocking `dbt test` step passes **`--indirect-selection cautious`**, so the
+> class-4 cross-boundary tests (fresh-vs-deferred) stay out of the report. PR #56 added this flag to
+> `main`'s inline build; here it lives on the separate `dbt test` step, and #56 was folded into this
+> PR rather than merged on its own.
 
 ## Docs-only PRs
 

--- a/docs/superpowers/plans/2026-07-27-pr-schema-diff-fix.md
+++ b/docs/superpowers/plans/2026-07-27-pr-schema-diff-fix.md
@@ -1,0 +1,898 @@
+# pr_schema_diff.sh Repair Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop `scripts/pr_schema_diff.sh` from aborting CI under `set -u` (issue #53) and repair the `get_node_by_name` defect that has made the per-model schema diff a silent no-op since the repository was created.
+
+**Architecture:** Three surgical edits to one bash script, guarded by a new dependency-free bash test harness that runs the real script against stubbed `bq` and `dbt` binaries placed first on `PATH`. The harness asserts on exit codes and on generated report files. A fourth change hardens the CI step. Validation is downstream-first: this repository has two example models and red CI, so the substantive proof runs against a real ~40-model manifest from `weightcare-pipeline-new`.
+
+**Tech Stack:** bash 4+, jq, GitHub Actions, dbt-core 1.10.8, BigQuery.
+
+**Spec:** `docs/superpowers/specs/2026-07-27-pr-schema-diff-set-u-fix-design.md`
+
+## Global Constraints
+
+- Target shell is bash 4+ (`mapfile` is used). CI is ubuntu-latest with bash 5. Stock macOS bash 3.2 is not supported.
+- `scripts/pr_schema_diff.sh` keeps `set -euo pipefail` on line 2. Do not relax it globally.
+- Keep `--maximum_bytes_billed=1000000000` on `bq_json`. The downstream fork removed it; that is a regression and must not be copied.
+- Keep the `[warn] Could not list tables in ...` diagnostic written into `orphans.md`. The downstream fork dropped it.
+- Tests must introduce no new dependency. No bats, no pip packages. Only bash, jq, coreutils.
+- **Ordering rule:** status classification reads the raw `bq` output. `as_json_array` is applied only where a value is handed to `jq`. Never normalize before classifying.
+- Out of scope, do not touch: `DIFF_SELECT` selection (issue #29), `scripts/drop_bq_dataset.sh` (issue #19), `scripts/pr_data_diff.sh`, query batching.
+- Nothing is committed to the upstream `main` branch. All work lands on branch `fix/53-pr-schema-diff-set-u`.
+- Tier 3 validation (a real downstream CI run) requires explicit human authorization and is not initiated by the implementer.
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `tests/test_pr_schema_diff.sh` | **Create.** Whole test harness: assertion helpers, sandbox builder, stub generators, six scenarios, summary. Self-contained so it can be copied for issue #19. |
+| `scripts/pr_schema_diff.sh` | **Modify.** Three edits: orphan block (Task 1), `get_node_by_name` (Task 2), status classification and JSON guards (Task 3). |
+| `Makefile` | **Modify.** Add `test-scripts` target and add it to `.PHONY`. |
+| `.github/workflows/ci.yml` | **Modify.** Add `continue-on-error` to the schema-diff step; add a harness step to the `lint` job. |
+
+The harness is deliberately one file. It is a test fixture, not production code, and keeping the stubs adjacent to the assertions they serve is what makes it copyable to the next `set -u` issue.
+
+---
+
+### Task 1: Test harness + fix the orphan block (issue #53)
+
+Delivers the harness skeleton and scenarios 1-4, then fixes the defect they expose. Scenarios 1-4 all concern the orphan block, so they gate one change.
+
+**Files:**
+- Create: `tests/test_pr_schema_diff.sh`
+- Modify: `scripts/pr_schema_diff.sh:309-360` (orphan block)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: shell functions later tasks reuse — `make_sandbox <mode>` (sets globals `SANDBOX`, `BQ_CALL_LOG`), `run_diff` (returns the script's exit code, sets `RUN_STDOUT`/`RUN_STDERR`), `assert_eq <expected> <actual> <msg>`, `assert_contains <haystack> <needle> <msg>`, `assert_not_contains <haystack> <needle> <msg>`, `pass <msg>`, `fail <msg>`. Scenario functions are named `scenario_1` .. `scenario_6`.
+
+- [ ] **Step 1: Write the harness with scenarios 1-4**
+
+Create `tests/test_pr_schema_diff.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Tests for scripts/pr_schema_diff.sh
+#
+# Dependency-free: requires bash 4+, jq, coreutils. No bats, no pip packages.
+# Runs the real script against stubbed `bq` and `dbt` binaries on PATH.
+#
+# Usage: bash tests/test_pr_schema_diff.sh
+#
+# Note: `set -e` is deliberately NOT used. The harness inspects non-zero exit
+# codes from the script under test; aborting on them would defeat the purpose.
+set -uo pipefail
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+SCRIPT="$REPO_ROOT/scripts/pr_schema_diff.sh"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass() { echo "    ok   - $1"; PASS_COUNT=$((PASS_COUNT + 1)); }
+fail() { echo "    FAIL - $1"; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+
+assert_eq() {
+  local expected=$1 actual=$2 msg=$3
+  if [[ "$expected" == "$actual" ]]; then
+    pass "$msg"
+  else
+    fail "$msg (expected '$expected', got '$actual')"
+  fi
+}
+
+assert_contains() {
+  local haystack=$1 needle=$2 msg=$3
+  if [[ "$haystack" == *"$needle"* ]]; then
+    pass "$msg"
+  else
+    fail "$msg (expected to find '$needle')"
+  fi
+}
+
+assert_not_contains() {
+  local haystack=$1 needle=$2 msg=$3
+  if [[ "$haystack" != *"$needle"* ]]; then
+    pass "$msg"
+  else
+    fail "$msg (did not expect to find '$needle')"
+  fi
+}
+
+# Fixture manifest: two models in prod dataset `analytics`.
+#   fct_example - exists in prod
+#   stg_example - has no prod counterpart, so exercises NEW_MODEL
+write_manifest() {
+  cat > "$1" <<'JSON'
+{
+  "nodes": {
+    "model.tpl.fct_example": {
+      "resource_type": "model", "name": "fct_example", "alias": "fct_example",
+      "database": "prodproj", "schema": "analytics",
+      "unique_id": "model.tpl.fct_example"
+    },
+    "model.tpl.stg_example": {
+      "resource_type": "model", "name": "stg_example", "alias": "stg_example",
+      "database": "prodproj", "schema": "analytics",
+      "unique_id": "model.tpl.stg_example"
+    }
+  },
+  "sources": {}
+}
+JSON
+}
+
+# Builds an isolated sandbox and sets SANDBOX and BQ_CALL_LOG.
+# $1 selects stub behaviour, consumed by the bq stub via STUB_MODE.
+make_sandbox() {
+  local mode=$1
+  SANDBOX=$(mktemp -d)
+  STUB_MODE=$mode
+  BQ_CALL_LOG="$SANDBOX/bq_calls.log"
+  mkdir -p "$SANDBOX/stubs" "$SANDBOX/target" "$SANDBOX/prod_state" "$SANDBOX/out"
+  : > "$BQ_CALL_LOG"
+
+  write_manifest "$SANDBOX/target/manifest.json"
+  write_manifest "$SANDBOX/prod_state/manifest.json"
+
+  cat > "$SANDBOX/stubs/dbt" <<'STUB'
+#!/usr/bin/env bash
+# Only `dbt ls` is exercised; every other subcommand is a no-op success.
+if [[ "${1:-}" == "ls" ]]; then
+  printf 'fct_example\nstg_example\n'
+fi
+exit 0
+STUB
+
+  cat > "$SANDBOX/stubs/bq" <<'STUB'
+#!/usr/bin/env bash
+# Stub BigQuery CLI. Records every invocation, then answers based on the
+# shape of the SQL and on STUB_MODE.
+args="$*"
+echo "$args" >> "$BQ_CALL_LOG"
+
+DEV_COLS='[{"column_name":"id","ordinal_position":1,"data_type":"INT64","is_nullable":"YES"},{"column_name":"amount","ordinal_position":2,"data_type":"NUMERIC","is_nullable":"YES"}]'
+PROD_COLS='[{"column_name":"id","ordinal_position":1,"data_type":"INT64","is_nullable":"YES"}]'
+
+case "$args" in
+  *TABLE_OPTIONS*)
+    echo '[]' ;;
+
+  *INFORMATION_SCHEMA.COLUMNS*)
+    if [[ "$STUB_MODE" == "banner_introspect" ]]; then
+      echo 'Welcome to BigQuery! Update available.'
+    elif [[ "$args" == *ci_pr_1* ]]; then
+      echo "$DEV_COLS"
+    elif [[ "$args" == *"table_name = 'fct_example'"* ]]; then
+      echo "$PROD_COLS"
+    else
+      echo '[]'
+    fi ;;
+
+  *"INFORMATION_SCHEMA.TABLES WHERE"*)
+    if [[ "$args" == *ci_pr_1* ]]; then
+      echo '[{"table_type":"BASE TABLE"}]'
+    elif [[ "$args" == *"table_name = 'fct_example'"* ]]; then
+      echo '[{"table_type":"BASE TABLE"}]'
+    else
+      echo '[]'
+    fi ;;
+
+  *INFORMATION_SCHEMA.TABLES*)
+    # Dataset-wide table listing, used only by the orphan block.
+    case "$STUB_MODE" in
+      denied)        echo 'BigQuery error: Access Denied' >&2; exit 1 ;;
+      has_orphan)    echo '[{"table_name":"legacy_junk","table_type":"BASE TABLE"}]' ;;
+      banner_tables) echo 'Welcome to BigQuery! Update available.' ;;
+      *)             echo '[{"table_name":"fct_example","table_type":"BASE TABLE"}]' ;;
+    esac ;;
+
+  *)
+    echo '[]' ;;
+esac
+exit 0
+STUB
+
+  chmod +x "$SANDBOX/stubs/bq" "$SANDBOX/stubs/dbt"
+}
+
+# Runs the script under test inside the sandbox. Returns its exit code and
+# sets RUN_STDOUT / RUN_STDERR. stdin is closed to mimic GitHub Actions.
+run_diff() {
+  local rc
+  RUN_STDOUT=$(
+    cd "$SANDBOX" || exit 99
+    PATH="$SANDBOX/stubs:$PATH" \
+    STUB_MODE="$STUB_MODE" \
+    BQ_CALL_LOG="$BQ_CALL_LOG" \
+    DBT_GCP_PROJECT_CI=ciproj \
+    DBT_BQ_DATASET=ci_pr_1 \
+    DBT_GCP_PROJECT_PROD=prodproj \
+    DBT_BQ_DATASET_PROD=analytics \
+    ARTIFACT_DIR="$SANDBOX/out" \
+      bash "$SCRIPT" 2>"$SANDBOX/stderr.txt" </dev/null
+  )
+  rc=$?
+  RUN_STDERR=$(cat "$SANDBOX/stderr.txt")
+  return $rc
+}
+
+cleanup() { [[ -n "${SANDBOX:-}" && -d "$SANDBOX" ]] && rm -rf "$SANDBOX"; }
+
+scenario_1() {
+  echo "  scenario 1: zero orphans (every prod table covered by the manifest)"
+  make_sandbox ok_no_orphans
+  run_diff; local rc=$?
+  assert_eq 0 "$rc" "exits 0 when no orphans are found"
+  assert_contains "$(cat "$SANDBOX/out/orphans.md")" "Found 0 orphan(s)." "reports zero orphans"
+  cleanup
+}
+
+scenario_2() {
+  echo "  scenario 2: prod dataset unreadable"
+  make_sandbox denied
+  run_diff; local rc=$?
+  assert_eq 0 "$rc" "exits 0 when the prod dataset cannot be listed"
+  assert_contains "$(cat "$SANDBOX/out/orphans.md")" "Could not list tables" \
+    "keeps the unreadable-dataset diagnostic in orphans.md"
+  cleanup
+}
+
+scenario_3() {
+  echo "  scenario 3: an orphan is present"
+  make_sandbox has_orphan
+  run_diff; local rc=$?
+  assert_eq 0 "$rc" "exits 0 when an orphan is found"
+  local report; report=$(cat "$SANDBOX/out/orphans.md")
+  assert_contains "$report" "Found 1 orphan(s)." "counts the orphan"
+  assert_contains "$report" "prodproj.analytics.legacy_junk" "names the orphan"
+  cleanup
+}
+
+scenario_4() {
+  echo "  scenario 4: bq returns a non-JSON banner for the table listing"
+  make_sandbox banner_tables
+  run_diff; local rc=$?
+  assert_eq 0 "$rc" "exits 0 when the table listing is unparseable"
+  cleanup
+}
+
+echo "test_pr_schema_diff.sh"
+scenario_1
+scenario_2
+scenario_3
+scenario_4
+
+echo ""
+echo "passed: $PASS_COUNT  failed: $FAIL_COUNT"
+[[ $FAIL_COUNT -eq 0 ]]
+```
+
+- [ ] **Step 2: Run the harness to verify scenarios 1, 2 and 4 fail**
+
+Run: `bash tests/test_pr_schema_diff.sh`
+
+Expected: FAIL. Scenarios 1, 2 and 4 report `exits 0 ... (expected '0', got '1')`, and stderr from the script contains `line 353: orphans: unbound variable`. Scenario 3 passes, because that is the only path where `orphans` gets assigned.
+
+This asymmetry is the bug: a clean prod dataset fails, a messy one passes.
+
+- [ ] **Step 3: Fix the orphan block**
+
+In `scripts/pr_schema_diff.sh`, replace everything from the `# Orphans report — only if we can read prod` comment (line 309) through the closing `fi` of the orphan examples block (line 360) with:
+
+```bash
+# Orphans report — best-effort, never fails CI.
+# Isolated in a subshell with relaxed error handling: this is a side report,
+# and a failure here must never abort the schema diff for changed models.
+orphans_md="$ARTIFACT_DIR/orphans.md"
+(
+  set +euo pipefail
+
+  echo "# Orphaned Production Relations" > "$orphans_md"
+  echo >> "$orphans_md"
+  echo "_Generated: $(date -u +"%Y-%m-%d %H:%M:%S UTC")_" >> "$orphans_md"
+  echo >> "$orphans_md"
+
+  # Build coverage set from manifest (prefer prod manifest, else PR manifest)
+  manifest_for_orphans="$PR_MANIFEST"
+  if [[ -f "$PROD_MANIFEST" ]]; then
+    manifest_for_orphans="$PROD_MANIFEST"
+  fi
+
+  coverage=$(jq -r '
+    def model_key($p): (.schema + "." + ((.alias // .name) // ""));
+    def source_key($p): (.schema + "." + ((.identifier // .name) // ""));
+    [
+      (.nodes | to_entries[] | .value | select(.resource_type=="model") | model_key(.)) ,
+      (.sources | to_entries[] | .value | source_key(.))
+    ] | flatten | unique | .[]' "$manifest_for_orphans" 2>/dev/null || true)
+
+  declare -A covered
+  while IFS= read -r line; do
+    [[ -n "$line" ]] && covered["$line"]=1
+  done <<< "$coverage"
+
+  # Explicitly initialized: `declare -a orphans` alone leaves the array unset,
+  # and `${#orphans[@]}` on an unset array is an unbound-variable error under
+  # `set -u` even on bash 5 (the 4.4 relaxation covers ${a[@]}, not ${#a[@]}).
+  declare -a orphans=()
+  for ds in "${PROD_DATASETS_ARR[@]}"; do
+    list_json=$(bq_json "$PROD_PROJECT" "SELECT table_name, table_type FROM \`$PROD_PROJECT.$ds\`.INFORMATION_SCHEMA.TABLES") || true
+    if [[ -z "$list_json" ]]; then
+      echo "[warn] Could not list tables in $PROD_PROJECT.$ds (no access?)" >> "$orphans_md"
+      continue
+    fi
+    # Guard the parse: bq can emit banner text that is not valid JSON.
+    table_names=$(printf '%s' "$list_json" | jq -r '.[].table_name' 2>/dev/null) || true
+    if [[ -z "$table_names" ]]; then
+      echo "[warn] Could not parse table list for $PROD_PROJECT.$ds" >> "$orphans_md"
+      continue
+    fi
+    while IFS= read -r name; do
+      [[ -z "$name" ]] && continue
+      key="$ds.$name"
+      if [[ -z "${covered[$key]:-}" ]]; then
+        orphans+=("$PROD_PROJECT.$ds.$name")
+      fi
+    done <<< "$table_names"
+  done
+
+  echo "Found ${#orphans[@]} orphan(s)." >> "$orphans_md"
+  if (( ${#orphans[@]} > 0 )); then
+    echo "" >> "$orphans_md"
+    echo "## Examples" >> "$orphans_md"
+    for o in "${orphans[@]:0:50}"; do
+      echo "- $o" >> "$orphans_md"
+    done
+  fi
+) || echo "[warn] Orphan detection encountered errors; see $orphans_md" >&2
+```
+
+Four changes are folded in here: the array is initialized, the `jq` parse is captured and guarded, the `< <(echo | jq)` process substitution becomes a `<<<` herestring, and the dead `tables_json=$(bq_table_type "$PROD_PROJECT" "$ds" "__all__" ...)` call is deleted — its result was never read and it issued a real BigQuery query on every run.
+
+- [ ] **Step 4: Run the harness to verify scenarios 1-4 pass**
+
+Run: `bash tests/test_pr_schema_diff.sh`
+
+Expected: PASS. `passed: 8  failed: 0`.
+
+- [ ] **Step 5: Verify the dead query is gone**
+
+Run: `grep -c '__all__' scripts/pr_schema_diff.sh`
+
+Expected: `0`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/test_pr_schema_diff.sh scripts/pr_schema_diff.sh
+git commit -m "fix(ci): stop schema diff aborting on uninitialized orphans array (#53)
+
+\`declare -a orphans\` left the array unset, and \`\${#orphans[@]}\` on an unset
+array is an unbound-variable error under \`set -u\` even on bash 5. The array is
+only assigned inside the \`orphans+=()\` branch, so the script survived only when
+at least one orphan existed: a clean prod dataset failed CI, a messy one passed.
+
+Initializes the array, guards the jq parse against non-JSON bq output, replaces
+the process substitution with a herestring, and isolates the whole block in a
+subshell so this best-effort side report can never abort the core diff. Also
+drops a dead bq_table_type '__all__' call that issued a real query per run.
+
+Adds tests/test_pr_schema_diff.sh, the repo's first shell test harness."
+```
+
+---
+
+### Task 2: Fix `get_node_by_name` — the silent no-op
+
+**Files:**
+- Modify: `tests/test_pr_schema_diff.sh` (add `scenario_5`, register it)
+- Modify: `scripts/pr_schema_diff.sh:76-83`
+
+**Interfaces:**
+- Consumes: `make_sandbox`, `run_diff`, `assert_eq`, `assert_contains`, `assert_not_contains` from Task 1.
+- Produces: `scenario_5`.
+
+- [ ] **Step 1: Write the failing test**
+
+In `tests/test_pr_schema_diff.sh`, add this function immediately after `scenario_4`:
+
+```bash
+scenario_5() {
+  echo "  scenario 5: regression guard — models actually resolve (Defect B)"
+  make_sandbox ok_no_orphans
+  run_diff; local rc=$?
+  assert_eq 0 "$rc" "exits 0"
+
+  # Every model returned by `dbt ls` must produce exactly one summary row and
+  # zero resolution warnings. Models with no prod counterpart satisfy the row
+  # requirement with status NEW_MODEL; the assertion is on row count and
+  # warning absence, not on status value.
+  assert_not_contains "$RUN_STDOUT" "Could not resolve model" \
+    "no model fails to resolve in the PR manifest"
+
+  local summary rows
+  summary=$(cat "$SANDBOX/out/schema-summary.md")
+  rows=$(grep -c '^| [a-z]' <<< "$summary")
+  assert_eq 2 "$rows" "summary table has one row per selected model"
+  assert_contains "$summary" "fct_example" "fct_example appears in the summary"
+  assert_contains "$summary" "stg_example" "stg_example appears in the summary"
+  assert_contains "$summary" "NEW_MODEL" "model with no prod counterpart is NEW_MODEL"
+  cleanup
+}
+```
+
+Register it by changing the scenario invocation list near the bottom of the file from:
+
+```bash
+scenario_4
+```
+
+to:
+
+```bash
+scenario_4
+scenario_5
+```
+
+- [ ] **Step 2: Run the harness to verify scenario 5 fails**
+
+Run: `bash tests/test_pr_schema_diff.sh`
+
+Expected: FAIL. Scenario 5 reports `no model fails to resolve in the PR manifest (did not expect to find 'Could not resolve model')` and `summary table has one row per selected model (expected '2', got '0')`. Scenarios 1-4 still pass.
+
+- [ ] **Step 3: Fix `get_node_by_name`**
+
+In `scripts/pr_schema_diff.sh`, replace lines 76-83:
+
+```bash
+# Helper: get model node JSON from manifest by name
+get_node_by_name() {
+  local manifest=$1 name=$2
+  jq -r --arg n "$2" '
+    .nodes 
+    | to_entries[]
+    | select(.value.resource_type=="model" and .value.name==$n)
+    | .value'
+}
+```
+
+with:
+
+```bash
+# Helper: get model node JSON from manifest by name
+# The manifest path must be passed to jq. Without it jq reads stdin, which is
+# empty under CI, so every lookup returned nothing and every model was skipped.
+get_node_by_name() {
+  local manifest=$1
+  jq -r --arg n "$2" '
+    .nodes
+    | to_entries[]
+    | select(.value.resource_type=="model" and .value.name==$n)
+    | .value' "$manifest"
+}
+```
+
+Two changes: `"$manifest"` is passed to `jq`, and the unused `name` local is dropped since the body reads `$2` directly.
+
+- [ ] **Step 4: Run the harness to verify all scenarios pass**
+
+Run: `bash tests/test_pr_schema_diff.sh`
+
+Expected: PASS. `passed: 14  failed: 0`.
+
+- [ ] **Step 5: Record the bq invocation count**
+
+Run:
+
+```bash
+bash -c '
+SANDBOX=$(mktemp -d); export SANDBOX
+source /dev/stdin <<< "$(sed -n "/^make_sandbox()/,/^}/p;/^write_manifest()/,/^}/p" tests/test_pr_schema_diff.sh)"
+make_sandbox ok_no_orphans
+cd "$SANDBOX" && PATH="$SANDBOX/stubs:$PATH" STUB_MODE=ok_no_orphans BQ_CALL_LOG="$BQ_CALL_LOG" \
+  DBT_GCP_PROJECT_CI=ciproj DBT_BQ_DATASET=ci_pr_1 DBT_GCP_PROJECT_PROD=prodproj \
+  DBT_BQ_DATASET_PROD=analytics ARTIFACT_DIR="$SANDBOX/out" \
+  bash '"$PWD"'/scripts/pr_schema_diff.sh >/dev/null 2>&1 </dev/null
+echo "bq invocations for 2 models: $(wc -l < "$BQ_CALL_LOG")"
+rm -rf "$SANDBOX"'
+```
+
+Expected: `13` — six per model plus one dataset listing. Write this number into the commit message. It is the input to the batching decision deferred in the spec.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/test_pr_schema_diff.sh scripts/pr_schema_diff.sh
+git commit -m "fix(ci): pass manifest path to jq in get_node_by_name
+
+get_node_by_name bound \`local manifest=\$1\` but never passed \"\$manifest\" to
+jq, so jq read stdin — empty under CI — and returned nothing. That function
+gates the per-model loop, so every model hit 'Could not resolve model X in PR
+manifest; skipping' and the summary table was emitted with a header and no
+rows. The per-model schema diff has never produced output, here or in the
+downstream fork. get_node_by_uid immediately below it passes the path
+correctly; the omission was isolated to this one helper.
+
+Measured cost of activating the loop: 6 bq invocations per model (13 total for
+the 2-model fixture). Batching is deferred per the design doc."
+```
+
+---
+
+### Task 3: Guard the newly reachable path
+
+Fixing Task 2 activates roughly 60 lines that have never executed. `jq --argjson` hard-fails on non-JSON, and under `set -e` that aborts the script. The guard must not disturb status classification, which reads the raw string.
+
+**Files:**
+- Modify: `tests/test_pr_schema_diff.sh` (add `scenario_6`, register it)
+- Modify: `scripts/pr_schema_diff.sh` (add helpers near `normalize_options`; rework lines 254-273)
+
+**Interfaces:**
+- Consumes: `make_sandbox`, `run_diff`, `assert_eq`, `assert_contains`, `assert_not_contains` from Task 1.
+- Produces: `scenario_6`; shell functions `is_json_array <string>` (returns 0 if the argument parses as a JSON array) and `as_json_array <string>` (echoes the argument if it is a JSON array, otherwise `[]`).
+
+- [ ] **Step 1: Write the failing test**
+
+In `tests/test_pr_schema_diff.sh`, add after `scenario_5`:
+
+```bash
+scenario_6() {
+  echo "  scenario 6: bq returns a non-JSON banner for column introspection"
+  make_sandbox banner_introspect
+  run_diff; local rc=$?
+  assert_eq 0 "$rc" "exits 0 when introspection output is unparseable"
+
+  # The requirement is that unparseable output is never reported as a clean
+  # diff. The exact status string is pinned here once observed.
+  local summary; summary=$(cat "$SANDBOX/out/schema-summary.md")
+  assert_contains "$summary" "NON_JSON" "unparseable introspection is marked NON_JSON"
+  cleanup
+}
+```
+
+Register it by changing `scenario_5` in the invocation list to:
+
+```bash
+scenario_5
+scenario_6
+```
+
+- [ ] **Step 2: Run the harness to verify scenario 6 fails**
+
+Run: `bash tests/test_pr_schema_diff.sh`
+
+Expected: FAIL. Scenario 6 reports a non-zero exit code, and stderr contains a `jq: error` about invalid JSON text passed to `--argjson`. Scenarios 1-5 still pass.
+
+- [ ] **Step 3: Add the JSON helpers**
+
+In `scripts/pr_schema_diff.sh`, insert immediately before the `normalize_options()` definition:
+
+```bash
+# Returns 0 if the argument parses as a JSON array.
+is_json_array() {
+  [[ -n "${1:-}" ]] && printf '%s' "$1" | jq -e 'type=="array"' >/dev/null 2>&1
+}
+
+# Echoes the argument if it is a JSON array, otherwise an empty array.
+# Apply ONLY where a value is handed to jq. Status classification reads the
+# raw bq output, because "Access Denied" is a signal that normalizing destroys.
+as_json_array() {
+  if is_json_array "${1:-}"; then
+    printf '%s' "$1"
+  else
+    printf '[]'
+  fi
+}
+```
+
+- [ ] **Step 4: Rework status classification and normalization**
+
+Replace lines 254-268 (from `status="OK"` through the two `prod_opts=` / `dev_opts=` assignments) with:
+
+```bash
+  # --- Classify from RAW output. Do not normalize before this block: ---
+  # as_json_array would rewrite "Access Denied" to "[]", which is non-empty and
+  # no longer matches the substring test, silently downgrading a permissions
+  # failure to a clean OK diff.
+  status="OK"
+  if [[ -z "$prod_cols_json" || "$prod_cols_json" == *"Access Denied"* ]]; then
+    status="AUTH_ERROR"
+  elif ! is_json_array "$prod_cols_json"; then
+    status="NON_JSON"
+  fi
+
+  # --- Normalize at the jq boundary. ---
+  dev_cols=$(as_json_array "${dev_cols_json:-}")
+  prod_cols=$(as_json_array "${prod_cols_json:-}")
+  dev_type_arr=$(as_json_array "${dev_type_json:-}")
+  prod_type_arr=$(as_json_array "${prod_type_json:-}")
+  dev_opts_arr=$(as_json_array "${dev_opts_json:-}")
+  prod_opts_arr=$(as_json_array "${prod_opts_json:-}")
+
+  # Detect new model (no prod table row). Only reclassify a clean OK status so
+  # AUTH_ERROR and NON_JSON are not overwritten.
+  prod_type=$(printf '%s' "$prod_type_arr" | jq -r '.[0].table_type // empty')
+  if [[ -z "$prod_type" && "$status" == "OK" ]]; then
+    status="NEW_MODEL"
+  fi
+  dev_type=$(printf '%s' "$dev_type_arr" | jq -r '.[0].table_type // empty')
+
+  # Normalize options
+  dev_opts=$(printf '%s' "$dev_opts_arr" | normalize_options)
+  prod_opts=$(printf '%s' "$prod_opts_arr" | normalize_options)
+```
+
+Then change the column-diff call on the following line from:
+
+```bash
+    col_diff=$(compute_column_diff "${dev_cols_json:-[]}" "${prod_cols_json:-[]}")
+```
+
+to:
+
+```bash
+    col_diff=$(compute_column_diff "$dev_cols" "$prod_cols")
+```
+
+`AUTH_ERROR` and `NON_JSON` rows skip the column diff, so `added`/`removed`/`changed` stay at their initialized `0`, satisfying the spec's requirement that `NON_JSON` rows appear with zero column counts.
+
+Note the original `NEW_MODEL` condition was `"$status" != "AUTH_ERROR"`; tightening it to `== "OK"` is what stops a `NON_JSON` row being relabelled `NEW_MODEL`.
+
+- [ ] **Step 5: Run the harness to verify all scenarios pass**
+
+Run: `bash tests/test_pr_schema_diff.sh`
+
+Expected: PASS. `passed: 16  failed: 0`.
+
+If scenario 6 reports a status other than `NON_JSON`, do not weaken the assertion — the classification block above is wrong and should be corrected until it emits `NON_JSON`.
+
+- [ ] **Step 6: Confirm no stale references remain**
+
+Run: `grep -n 'cols_json:-\[\]\|dev_opts_json:-\[\]\|prod_opts_json:-\[\]' scripts/pr_schema_diff.sh`
+
+Expected: no output. All jq consumers now read the normalized variables.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tests/test_pr_schema_diff.sh scripts/pr_schema_diff.sh
+git commit -m "fix(ci): guard non-JSON bq output in the per-model schema diff
+
+Fixing get_node_by_name activated ~60 lines that had never executed. Those
+lines pass bq output to jq --argjson, which hard-fails on non-JSON, aborting
+the script under set -e whenever bq emits banner or error text.
+
+Adds is_json_array/as_json_array and a NON_JSON status. Classification reads
+the raw output and normalization happens only at the jq boundary: normalizing
+first would rewrite 'Access Denied' to '[]', which no longer matches the
+substring test, silently downgrading a permissions failure to a clean OK diff.
+NEW_MODEL detection is tightened to only reclassify an OK status so it cannot
+mask AUTH_ERROR or NON_JSON."
+```
+
+---
+
+### Task 4: Wire the harness into Make and CI, and harden the CI step
+
+**Files:**
+- Modify: `Makefile:1` (`.PHONY`) and append a target
+- Modify: `.github/workflows/ci.yml` (lint job; schema-diff step)
+
+**Interfaces:**
+- Consumes: `tests/test_pr_schema_diff.sh` from Tasks 1-3.
+- Produces: `make test-scripts`.
+
+- [ ] **Step 1: Add the Makefile target**
+
+Change line 1 of `Makefile` from:
+
+```make
+.PHONY: init deps build test lint lint-fix docs compare clean freshness
+```
+
+to:
+
+```make
+.PHONY: init deps build test test-scripts lint lint-fix docs compare clean freshness
+```
+
+Then add after the existing `test:` target (which ends with the `dbt test` line):
+
+```make
+# Shell script tests. No warehouse connection, no credentials, no cost.
+test-scripts:
+	bash tests/test_pr_schema_diff.sh
+```
+
+Use a real tab for the recipe line, not spaces.
+
+- [ ] **Step 2: Verify the target runs**
+
+Run: `make test-scripts`
+
+Expected: PASS, `passed: 16  failed: 0`.
+
+- [ ] **Step 3: Add the harness to the CI lint job**
+
+In `.github/workflows/ci.yml`, in the `lint` job, insert this step immediately after the `- uses: actions/checkout@v5` step and before `- uses: actions/setup-python@v5`:
+
+```yaml
+      - name: Test shell scripts
+        run: bash tests/test_pr_schema_diff.sh
+```
+
+It goes in `lint` rather than `bigquery-ci` because the harness needs no GCP credentials and runs in seconds, so it fails fast before the expensive job starts.
+
+- [ ] **Step 4: Harden the schema-diff step**
+
+In the `bigquery-ci` job, change:
+
+```yaml
+      - name: Generate schema diffs for changed models
+        if: ${{ steps.dbt_build.outcome == 'success' }}
+        run: bash scripts/pr_schema_diff.sh
+```
+
+to:
+
+```yaml
+      - name: Generate schema diffs for changed models
+        if: ${{ steps.dbt_build.outcome == 'success' }}
+        continue-on-error: true
+        run: bash scripts/pr_schema_diff.sh
+```
+
+This is defence in depth. Task 1 removes the known failure; this prevents the class, and matches the `continue-on-error` already on the neighbouring docs-generate and artifact-upload steps.
+
+- [ ] **Step 5: Validate the workflow YAML parses**
+
+Run: `python3 -c "import yaml,sys; d=yaml.safe_load(open('.github/workflows/ci.yml')); print('lint steps:', len(d['jobs']['lint']['steps'])); print('schema step continue-on-error:', [s.get('continue-on-error') for s in d['jobs']['bigquery-ci']['steps'] if 'schema diff' in str(s.get('name','')).lower()])"`
+
+Expected: `lint steps: 5` and `schema step continue-on-error: [True]`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Makefile .github/workflows/ci.yml
+git commit -m "ci: run shell tests in the lint job, harden the schema-diff step
+
+Adds \`make test-scripts\` and runs the harness in the lint job, where it needs
+no GCP credentials and fails fast before the expensive bigquery-ci job.
+
+Adds continue-on-error to the schema-diff step. Its neighbours already have it;
+without it a non-zero exit from a best-effort reporting step fails the whole PR
+build, which is what made #53 severe rather than cosmetic."
+```
+
+---
+
+### Task 5: Tier 2 validation against a real downstream manifest
+
+The stub fixture has two models. This tier runs the fixed script against a real ~40-model manifest to prove the Task 2 fix at realistic scale and to produce the true `bq` invocation count. No credentials, no BigQuery spend, no production impact.
+
+**Files:**
+- Create: `docs/superpowers/specs/2026-07-27-tier2-validation-results.md`
+- Modify: none
+
+**Interfaces:**
+- Consumes: the fixed `scripts/pr_schema_diff.sh` and the stub generators in `tests/test_pr_schema_diff.sh`.
+- Produces: a recorded model count, `bq` invocation count, and extrapolated query total for the batching decision.
+
+- [ ] **Step 1: Clone the downstream repository into the scratchpad**
+
+```bash
+WORK=$(mktemp -d)
+git clone --depth 1 https://github.com/jasonbhart/weightcare-pipeline-new.git "$WORK/wc"
+echo "$WORK"
+```
+
+The repository is ~8.7MB. If the clone fails on authentication, stop and report — do not attempt to work around it.
+
+- [ ] **Step 2: Generate a real manifest offline**
+
+```bash
+cd "$WORK/wc"
+python3 -m venv .venv && . .venv/bin/activate
+pip install -q "dbt-core==1.10.8" "dbt-bigquery==1.10.1"
+dbt deps
+DBT_PROFILES_DIR=./profiles DBT_TARGET=ci \
+DBT_GCP_PROJECT_CI=offline-parse DBT_BQ_DATASET=offline_parse DBT_BQ_LOCATION=US \
+  dbt parse
+ls -la target/manifest.json
+```
+
+`dbt parse` builds the manifest from source files without contacting BigQuery. If it insists on a connection, fall back to `dbt ls --output name` with the same env vars, which also materialises `target/manifest.json`.
+
+- [ ] **Step 3: Run the fixed script against the real manifest**
+
+```bash
+TPL="/Volumes/AnmolxHDD/Anmol/Macbook Pro Backup/Documents/GitHub/dbt-core-gcloud-template"
+mkdir -p "$WORK/run/stubs" "$WORK/run/out"
+cp "$WORK/wc/target/manifest.json" "$WORK/run/manifest-real.json"
+mkdir -p "$WORK/run/target" "$WORK/run/prod_state"
+cp "$WORK/run/manifest-real.json" "$WORK/run/target/manifest.json"
+cp "$WORK/run/manifest-real.json" "$WORK/run/prod_state/manifest.json"
+
+# Stubs mirror the harness, but drive `dbt ls` from the real manifest so the
+# model list matches production rather than the two-model fixture.
+cat > "$WORK/run/stubs/dbt" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "ls" ]]; then
+  jq -r '.nodes | to_entries[] | .value | select(.resource_type=="model") | .name' \
+    "$REAL_MANIFEST"
+fi
+exit 0
+EOF
+
+cat > "$WORK/run/stubs/bq" <<'EOF'
+#!/usr/bin/env bash
+echo "$*" >> "$BQ_CALL_LOG"
+case "$*" in
+  *TABLE_OPTIONS*) echo '[]' ;;
+  *INFORMATION_SCHEMA.COLUMNS*) echo '[{"column_name":"id","ordinal_position":1,"data_type":"INT64","is_nullable":"YES"}]' ;;
+  *"INFORMATION_SCHEMA.TABLES WHERE"*) echo '[{"table_type":"BASE TABLE"}]' ;;
+  *INFORMATION_SCHEMA.TABLES*) echo '[]' ;;
+  *) echo '[]' ;;
+esac
+exit 0
+EOF
+chmod +x "$WORK/run/stubs/bq" "$WORK/run/stubs/dbt"
+
+cd "$WORK/run"
+: > "$WORK/run/bq_calls.log"
+PATH="$WORK/run/stubs:$PATH" \
+REAL_MANIFEST="$WORK/run/manifest-real.json" \
+BQ_CALL_LOG="$WORK/run/bq_calls.log" \
+DBT_GCP_PROJECT_CI=ciproj DBT_BQ_DATASET=ci_pr_1 \
+DBT_GCP_PROJECT_PROD=prodproj DBT_BQ_DATASET_PROD=dbt_pipeline \
+ARTIFACT_DIR="$WORK/run/out" \
+  bash "$TPL/scripts/pr_schema_diff.sh" > "$WORK/run/stdout.txt" 2>"$WORK/run/stderr.txt" </dev/null
+echo "exit: $?"
+```
+
+- [ ] **Step 4: Assert the results**
+
+```bash
+echo "models selected : $(PATH="$WORK/run/stubs:$PATH" REAL_MANIFEST="$WORK/run/manifest-real.json" dbt ls | wc -l)"
+echo "unresolved      : $(grep -c 'Could not resolve model' "$WORK/run/stdout.txt" || true)"
+echo "summary rows    : $(grep -c '^| [a-z]' "$WORK/run/out/schema-summary.md" || true)"
+echo "bq invocations  : $(wc -l < "$WORK/run/bq_calls.log")"
+```
+
+Expected: exit `0`; `unresolved` is `0`; `summary rows` equals `models selected`; `bq invocations` is approximately `6 × models + 1`.
+
+If `unresolved` is greater than zero, the Task 2 fix does not hold against a real manifest. Stop and report rather than adjusting the assertion.
+
+- [ ] **Step 5: Record the results**
+
+Create `docs/superpowers/specs/2026-07-27-tier2-validation-results.md` with the four measured numbers, the extrapolated wall-clock at an assumed 2-6 seconds per `bq` invocation, and a one-line recommendation on whether the deferred batching work is warranted. Recommend batching if the extrapolated addition exceeds five minutes.
+
+- [ ] **Step 6: Clean up and commit**
+
+```bash
+rm -rf "$WORK"
+git add docs/superpowers/specs/2026-07-27-tier2-validation-results.md
+git commit -m "docs: Tier 2 validation results against a real downstream manifest
+
+Runs the fixed script against weightcare-pipeline-new's real manifest with
+stubbed bq. Records model count, resolution failures, summary row count and
+measured bq invocations, and makes a batching recommendation from the
+extrapolated wall-clock. No credentials, no BigQuery spend."
+```
+
+---
+
+## Stopping point
+
+Tasks 1-5 complete the work that can be done without spending money or touching a production project.
+
+**Do not proceed past this point without explicit human authorization.** The remaining spec items are:
+
+- **Tier 3** — a draft PR on `jasonbhart/weightcare-pipeline-new` triggering its real `bigquery-ci` job. Costs real BigQuery spend against a production GCP project, takes ~17 minutes, and is visible to the repository owner. Access is push, not admin.
+- **Upstream PR** — open against `domainmethods/dbt-core-gcloud-template`, closing issue #53 and citing the Tier 2 and Tier 3 results.
+- **New upstream issue** for Defect B, cross-referencing #53, carrying the evidence from the design document.
+- **Downstream PR** — Tasks 2 and 3 only, since `weightcare-pipeline-new` already has the Task 1 fix. Opened for the owner's review, never merged unilaterally.
+
+Report the Tier 2 numbers and ask which of these to proceed with.

--- a/docs/superpowers/plans/2026-08-10-ci-data-diff-accuracy.md
+++ b/docs/superpowers/plans/2026-08-10-ci-data-diff-accuracy.md
@@ -1,0 +1,384 @@
+# CI Data-Diff Accuracy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the template's PR diffs trustworthy — no data *or* schema diff on docs-only PRs, and a data diff that isn't suppressed by an unrelated failing data test.
+
+**Architecture:** Three CI-script fixes sharing one selection pattern. (1) Wire the git-diff scope (`get_changed_models.sh`) into `$GITHUB_ENV` and make `pr_data_diff.sh` honour it — exiting immediately when no models changed instead of falling back to `state:modified+`/all-models. (2) Build models without tests in the gating step and run `dbt test` as a separate non-blocking step, so a red test no longer skips every diff/comment step. (3) Apply the same selection precedence to `pr_schema_diff.sh` so docs-only PRs skip the schema diff too.
+
+**Tech Stack:** GitHub Actions, bash, dbt-core 1.10.8 / dbt-bigquery 1.10.1, BigQuery. Dependency-free shell test harness (bash 4+, jq, coreutils) — same pattern as `tests/test_pr_schema_diff.sh`.
+
+## Global Constraints
+
+- dbt-core **1.10.8**, dbt-bigquery **1.10.1** — `dbt build --exclude-resource-type test` is supported at this floor (added in dbt 1.8); do not use flags newer than 1.10. Task 2 includes a verification step for the flag.
+- Shell tests must be dependency-free (no bats, no pip): bash 4+, `jq`, coreutils only. Stub `dbt`/`bq`/`gsutil` on `PATH`. Do **not** use `set -e` in the harness.
+- Scope is the **template repo only** (`dbt-core-gcloud-template`). Do not modify `jasonbhart/weightcare-pipeline-new`.
+- Do not change the data-diff SQL macro (`macros/compare_dev_prod.sql`) or `compare_template.sql` — the set-operation bug is tracked separately.
+- Commit messages: neutral, conventional-commit style. No co-author trailers.
+
+---
+
+## Background / Rationale (spec)
+
+Empirical validation (test PRs in a downstream deployment) surfaced three problems. This plan fixes the CI-orchestration issues in the template; source-data drift is already mitigated here and is validated, not coded.
+
+1. **Docs-only PRs don't cleanly produce "no diff" (FIX HERE — Tasks 1 & 3).**
+   `get_changed_models.sh` computes `HAS_MODEL_CHANGES` / `DIFF_SELECT`, but the "Detect changed dbt files" step (`.github/workflows/ci.yml:53-55`) **never pipes them into `$GITHUB_ENV`**, so they are unavailable downstream. Consequences:
+   - `scripts/ci_build.sh:50` reads `${HAS_MODEL_CHANGES:-true}` → always `true` → the docs-only "parse-only" tier never fires.
+   - `scripts/pr_data_diff.sh:36-49` **and** `scripts/pr_schema_diff.sh:56-67` ignore the git scope and select via `state:modified+` (or all models if no manifest). A stale/version-mismatched prod manifest makes `state:modified+` flag *every* model, so a docs-only PR attempts to diff the whole project.
+
+2. **A single red data test suppresses the entire data diff (FIX HERE — Task 2).**
+   `ci_build.sh` runs `dbt build` (models **and** tests). Every diff/comment step is gated on `steps.dbt_build.outcome == 'success'` (`ci.yml:109,114,124,130,156,170`). One failing `assert_*`/generic test anywhere in the selected lineage fails the build → all diffs are `skipped`.
+
+3. **Source-data drift (NOTE ONLY — already mitigated in the template).**
+   The template builds with `state:modified+ --defer --state prod_state` (`ci_build.sh:75`), deferring unchanged ancestors to prod — the correct approach. (Drift seen downstream came from a `+model+` variant that rebuilds ancestors; the template does not use it.) See **Manual Validation & Follow-ups**.
+
+## Risks & Trade-offs
+
+- **Loss of test-blocking (Task 2).** `dbt build` normally *skips* a model when an upstream test fails. Building with `--exclude-resource-type test` removes that gate: models build regardless of data-quality results. This is intended for a diff/CI-preview run (we want the diff even when data tests are red), but it means the ephemeral CI dataset may contain rows an upstream test would have rejected. The separate `dbt test` step keeps failures **visible** (its own red check); it just no longer suppresses the diff. Document this in the `ci_build.sh` header.
+- **Line-number references are pre-Task-1.** Tasks are ordered 1→2→3; each task's line numbers describe the file *before that task's own edits*. When a task edits a file an earlier task already touched (`ci.yml`), anchor on the quoted code strings shown, not on absolute line numbers.
+- **Docs-only ⇒ no comment at all.** When `pr_data_diff.sh` exits early, it never writes `diff_reports/summary.md`, so the "Post summary comment" step (`ci.yml:170`, gated on `hashFiles('diff_reports/summary.md')`) is skipped and no data-diff comment is posted. That satisfies "no diffs". If a reviewer would rather see an explicit "no data changes" note, that's a follow-up, not this plan.
+- **`--defer` permissions.** If the CI service account cannot read the prod dataset, `--defer` silently rebuilds ancestors → drift. Only a live no-op PR catches this; it's in the validation checklist.
+
+## File Structure
+
+- `.github/workflows/ci.yml` — export detect-step output to `$GITHUB_ENV` (Task 1); add a non-blocking `dbt test` step (Task 2); run the new harnesses in the lint job (Tasks 1, 3).
+- `scripts/pr_data_diff.sh` — top-of-script short-circuit + selection precedence honouring `HAS_MODEL_CHANGES`/`DIFF_SELECT` (Task 1).
+- `scripts/pr_schema_diff.sh` — same short-circuit + precedence (Task 3).
+- `scripts/ci_build.sh` — build with `--exclude-resource-type test`; export resolved select/defer for the test step; updated header (Task 2).
+- `tests/test_pr_data_diff.sh` — new harness for data-diff selection (Task 1).
+- `tests/test_ci_build.sh` — new harness for build-command construction (Task 2).
+- `tests/test_pr_schema_diff.sh` — extend with docs-only/`DIFF_SELECT` scenarios (Task 3).
+
+The selection precedence (short-circuit → `DIFF_SELECT` → `state:modified+` → all) is identical in Tasks 1 and 3. If a third consumer ever needs it, extract `scripts/select_changed_models.sh`; two copies do not yet justify the indirection (YAGNI).
+
+---
+
+### Task 1: Honour git-diff scope in the data diff (docs-only → no data diff)
+
+**Files:**
+- Modify: `.github/workflows/ci.yml:53-55` (detect step) and lint-job step (`:19` area)
+- Modify: `scripts/pr_data_diff.sh` — add early guard after env setup (~`:14`); replace selection block (`:35-49`)
+- Create: `tests/test_pr_data_diff.sh`
+
+**Interfaces:**
+- Consumes (from detect step, now exported): `HAS_MODEL_CHANGES` (`"true"`/`"false"`), `DIFF_SELECT` (space-separated `name+` selectors, possibly empty).
+- Produces: `pr_data_diff.sh` prints `No models to diff.` and exits 0 when `HAS_MODEL_CHANGES=false`; else selects via `DIFF_SELECT` when non-empty, else `state:modified+`, else all models.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_pr_data_diff.sh`. Stub `dbt` (and `gsutil`, so the manifest branch is deterministic) on `PATH`; run the real script; assert on stdout and the recorded `dbt` calls. `dbt run-operation` is stubbed to emit one SUMMARY line so the script completes without BigQuery.
+
+```bash
+#!/usr/bin/env bash
+# Tests for scripts/pr_data_diff.sh model-selection logic.
+# Dependency-free: bash 4+, coreutils. Stubs dbt/gsutil on PATH. No `set -e`.
+set -uo pipefail
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+SCRIPT="$REPO_ROOT/scripts/pr_data_diff.sh"
+PASS_COUNT=0; FAIL_COUNT=0
+pass() { echo "    ok   - $1"; PASS_COUNT=$((PASS_COUNT + 1)); }
+fail() { echo "    FAIL - $1"; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+assert_contains() { [[ "$1" == *"$2"* ]] && pass "$3" || fail "$3 (missing '$2')"; }
+assert_not_contains() { [[ "$1" != *"$2"* ]] && pass "$3" || fail "$3 (unexpected '$2')"; }
+
+make_sandbox() {
+  SANDBOX=$(mktemp -d); DBT_CALL_LOG="$SANDBOX/dbt_calls.log"; mkdir -p "$SANDBOX/bin"
+  cat > "$SANDBOX/bin/dbt" <<'STUB'
+#!/usr/bin/env bash
+echo "dbt $*" >> "$DBT_CALL_LOG"
+case "$1" in
+  ls) printf '%s\n' model_a model_b ;;
+  run-operation) echo "SUMMARY|table=model_a|dev=1|prod=1|dev_not_in_prod=0|prod_not_in_dev=0" ;;
+  *) : ;;
+esac
+STUB
+  chmod +x "$SANDBOX/bin/dbt"
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$SANDBOX/bin/gsutil"; chmod +x "$SANDBOX/bin/gsutil"
+  export DBT_CALL_LOG
+}
+
+run_case() {  # $1 = extra env assignments; sets RUN_OUT and DBT_CALL_LOG
+  make_sandbox
+  [[ "${WITH_MANIFEST:-0}" == "1" ]] && { mkdir -p "$SANDBOX/prod_state"; echo '{}' > "$SANDBOX/prod_state/manifest.json"; }
+  RUN_OUT=$(cd "$SANDBOX" && env -i PATH="$SANDBOX/bin:/usr/bin:/bin" \
+    DBT_CALL_LOG="$DBT_CALL_LOG" ARTIFACT_DIR="$SANDBOX/diff_reports" \
+    DBT_GCP_PROJECT_CI=ciproj DBT_BQ_DATASET=ci_ds DBT_GCP_PROJECT_PROD=prodproj \
+    $1 bash "$SCRIPT" 2>&1)
+}
+
+echo "scenario 1: docs-only (HAS_MODEL_CHANGES=false) diffs nothing, no dbt ls"
+run_case 'HAS_MODEL_CHANGES=false'
+assert_contains "$RUN_OUT" "No models to diff" "exits early with no models"
+assert_not_contains "$(cat "$DBT_CALL_LOG")" "ls" "never calls dbt ls"
+
+echo "scenario 2: DIFF_SELECT is used verbatim, not state:modified+"
+run_case 'HAS_MODEL_CHANGES=true DIFF_SELECT=fct_example+'
+assert_contains "$(cat "$DBT_CALL_LOG")" "ls --select fct_example+" "selects via DIFF_SELECT"
+assert_not_contains "$(cat "$DBT_CALL_LOG")" "state:modified+" "does not use state fallback"
+
+echo "scenario 3: no DIFF_SELECT, manifest present → state:modified+"
+WITH_MANIFEST=1 run_case 'HAS_MODEL_CHANGES=true'
+assert_contains "$(cat "$DBT_CALL_LOG")" "state:modified+" "uses state comparison when scope absent"
+
+echo "results: passed: $PASS_COUNT, failed: $FAIL_COUNT"
+[[ $FAIL_COUNT -eq 0 ]]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bash tests/test_pr_data_diff.sh`
+Expected: FAIL — scenario 1 fails (current script ignores `HAS_MODEL_CHANGES` and calls `dbt ls`); scenario 2 fails (script never reads `DIFF_SELECT`).
+
+- [ ] **Step 3: Add a top-of-script short-circuit in `scripts/pr_data_diff.sh`**
+
+Immediately after the env setup (after `PROD_PROJECT=${DBT_GCP_PROJECT_PROD:-}` at `:14`, before the `=== Data Diff State Detection ===` manifest block), insert:
+
+```bash
+# Docs/config-only PRs change no models — skip the diff entirely (no gsutil, no dbt).
+if [[ "${HAS_MODEL_CHANGES:-true}" == "false" ]]; then
+  echo "No dbt model changes detected in this PR. No models to diff."
+  exit 0
+fi
+```
+
+- [ ] **Step 4: Replace the selection block in `scripts/pr_data_diff.sh:35-49`**
+
+```bash
+echo ""
+echo "=== Model Selection ==="
+if [[ -n "${DIFF_SELECT:-}" ]]; then
+  echo "Using git-diff scope: ${DIFF_SELECT}"
+  # DIFF_SELECT is intentionally unquoted so multiple 'name+' tokens expand as separate args.
+  mapfile -t MODELS < <(dbt ls --select ${DIFF_SELECT} --resource-type model --output name --quiet 2>/dev/null || true)
+elif [[ -f prod_state/manifest.json ]]; then
+  echo "Using state comparison to find changed models..."
+  mapfile -t MODELS < <(dbt ls --select "state:modified+" --state prod_state --resource-type model --output name --quiet 2>/dev/null || true)
+else
+  echo "No git scope and no production manifest; selecting all models..."
+  mapfile -t MODELS < <(dbt ls --resource-type model --output name --quiet 2>/dev/null || true)
+fi
+echo "Selected ${#MODELS[@]} model(s)."
+```
+
+Keep the existing empty-guard at `:51-54`. Note: a macro/config/YAML-only change sets `HAS_MODEL_CHANGES=true` but leaves `DIFF_SELECT` empty (no model/seed/snapshot files) → the `state:modified+` branch runs, which is correct for those changes.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `bash tests/test_pr_data_diff.sh`
+Expected: PASS (all three scenarios green).
+
+- [ ] **Step 6: Wire the detect step into `$GITHUB_ENV`**
+
+In `.github/workflows/ci.yml`, change the detect step (`:53-55`):
+
+```yaml
+      - name: Detect changed dbt files
+        id: changes
+        run: |
+          output=$(bash scripts/get_changed_models.sh)
+          echo "$output"
+          echo "$output" >> "$GITHUB_ENV"
+```
+
+- [ ] **Step 7: Run the harness in the lint job**
+
+In `.github/workflows/ci.yml`, replace the existing `run: bash tests/test_pr_schema_diff.sh` (`:19`) with:
+
+```yaml
+        run: |
+          bash tests/test_pr_schema_diff.sh
+          bash tests/test_pr_data_diff.sh
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add scripts/pr_data_diff.sh tests/test_pr_data_diff.sh .github/workflows/ci.yml
+git commit -m "fix(ci): data diff honours git-diff scope; docs-only PRs diff nothing"
+```
+
+---
+
+### Task 2: Decouple tests from the diff gate (a red test no longer suppresses the diff)
+
+**Files:**
+- Modify: `scripts/ci_build.sh` (build invocations at the `dbt build ...` lines; header `:4-8`; add export block before end)
+- Modify: `.github/workflows/ci.yml` — add a non-blocking test step immediately after the `dbt_build` step (`Slim CI build`)
+- Create: `tests/test_ci_build.sh`
+
+**Interfaces:**
+- Consumes: `HAS_MODEL_CHANGES`, internal `HAS_STATE`, prod_state manifest.
+- Produces: `ci_build.sh` runs models with `--exclude-resource-type test` and exports `CI_SELECT` / `CI_DEFER` to `$GITHUB_ENV`; the new `dbt test` step consumes them with `continue-on-error: true`.
+
+- [ ] **Step 1: Verify the flag exists at the version floor**
+
+Run: `dbt build --help | grep -- --exclude-resource-type`
+Expected: the option is listed (dbt 1.10). If absent, stop — fall back to `dbt run` + `dbt seed` + `dbt snapshot` for the build instead, and adjust the assertions below.
+
+- [ ] **Step 2: Write the failing test**
+
+Create `tests/test_ci_build.sh`; stub `dbt` (log args), `gsutil` (no manifest), `python3` unused here.
+
+```bash
+#!/usr/bin/env bash
+set -uo pipefail
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+SCRIPT="$REPO_ROOT/scripts/ci_build.sh"
+PASS_COUNT=0; FAIL_COUNT=0
+pass(){ echo "    ok   - $1"; PASS_COUNT=$((PASS_COUNT+1)); }
+fail(){ echo "    FAIL - $1"; FAIL_COUNT=$((FAIL_COUNT+1)); }
+assert_contains(){ [[ "$1" == *"$2"* ]] && pass "$3" || fail "$3 (missing '$2')"; }
+
+SANDBOX=$(mktemp -d); mkdir -p "$SANDBOX/bin"
+printf '#!/usr/bin/env bash\necho "dbt $*" >> "$DBT_CALL_LOG"\n' > "$SANDBOX/bin/dbt"
+printf '#!/usr/bin/env bash\nexit 1\n' > "$SANDBOX/bin/gsutil"   # no manifest → full build
+chmod +x "$SANDBOX/bin/dbt" "$SANDBOX/bin/gsutil"
+export DBT_CALL_LOG="$SANDBOX/calls.log"
+
+echo "scenario: model changes, no state → build excludes tests"
+( cd "$SANDBOX" && env -i PATH="$SANDBOX/bin:/usr/bin:/bin" DBT_CALL_LOG="$DBT_CALL_LOG" \
+    HAS_MODEL_CHANGES=true bash "$SCRIPT" >/dev/null 2>&1 )
+assert_contains "$(cat "$DBT_CALL_LOG")" "build --target ci --exclude-resource-type test" "build skips tests"
+
+echo "results: passed: $PASS_COUNT, failed: $FAIL_COUNT"
+[[ $FAIL_COUNT -eq 0 ]]
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `bash tests/test_ci_build.sh`
+Expected: FAIL — current `ci_build.sh` runs `dbt build --target ci` without `--exclude-resource-type test`.
+
+- [ ] **Step 4: Add `--exclude-resource-type test` and export the resolved select**
+
+In `scripts/ci_build.sh`, append `--exclude-resource-type test` to each `dbt build` invocation. Slim build (`:75`):
+
+```bash
+  echo "Starting Slim CI build with defer (models only; tests run separately)..."
+  dbt build --target ci --select "state:modified+" --defer --state prod_state --exclude-resource-type test
+  CI_SELECT="state:modified+"; CI_DEFER="--defer --state prod_state"
+```
+
+Full-build fallbacks (the `dbt build --target ci` at `:67` and `:79`): change each to `dbt build --target ci --exclude-resource-type test` and set `CI_SELECT=""; CI_DEFER=""` next to them. At the end of the script (before the final `echo "=== Build Complete ==="`), export for later steps:
+
+```bash
+if [[ -n "${GITHUB_ENV:-}" ]]; then
+  echo "CI_SELECT=${CI_SELECT:-}" >> "$GITHUB_ENV"
+  echo "CI_DEFER=${CI_DEFER:-}" >> "$GITHUB_ENV"
+fi
+```
+
+Update the header comment (`:4-8`) to note: models are built without tests; `dbt test` runs as a separate non-blocking CI step; this removes dbt's upstream test-blocking (see Risks & Trade-offs).
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `bash tests/test_ci_build.sh`
+Expected: PASS.
+
+- [ ] **Step 6: Add the non-blocking test step in `ci.yml`**
+
+Immediately after the `dbt_build` step (the `Slim CI build ...` step), add:
+
+```yaml
+      - name: Run dbt tests (non-blocking; does not gate diffs)
+        id: dbt_test
+        if: ${{ steps.dbt_build.outcome == 'success' && env.HAS_MODEL_CHANGES != 'false' }}
+        continue-on-error: true
+        run: |
+          dbt test --target ci ${CI_SELECT:+--select "$CI_SELECT"} ${CI_DEFER}
+```
+
+Leave every diff/comment step gated on `steps.dbt_build.outcome == 'success'` — that outcome now reflects model-build success only.
+
+- [ ] **Step 7: Run all harnesses**
+
+Run: `bash tests/test_pr_data_diff.sh && bash tests/test_ci_build.sh`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add scripts/ci_build.sh tests/test_ci_build.sh .github/workflows/ci.yml
+git commit -m "fix(ci): build models without tests; run dbt test as a non-blocking step so diffs aren't suppressed"
+```
+
+---
+
+### Task 3: Apply the same scope to the schema diff (docs-only → no schema diff)
+
+**Files:**
+- Modify: `scripts/pr_schema_diff.sh` — add top-of-script short-circuit; replace selection block (`:56-67`)
+- Modify: `tests/test_pr_schema_diff.sh` — add docs-only and `DIFF_SELECT` scenarios
+
+**Interfaces:**
+- Consumes: `HAS_MODEL_CHANGES`, `DIFF_SELECT` (same as Task 1).
+- Produces: `pr_schema_diff.sh` exits 0 with no schema diff when `HAS_MODEL_CHANGES=false`; else uses `DIFF_SELECT` → `state:modified+` → all.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_pr_schema_diff.sh` (reuse its existing sandbox/stub helpers):
+
+```bash
+echo "scenario: docs-only (HAS_MODEL_CHANGES=false) produces no schema diff"
+# Run the script with HAS_MODEL_CHANGES=false; assert early exit and no dbt ls.
+OUT=$(HAS_MODEL_CHANGES=false run_script)   # use the file's existing runner helper
+assert_contains "$OUT" "No models" "schema diff exits early on docs-only"
+
+echo "scenario: DIFF_SELECT is honoured over state:modified+"
+OUT=$(HAS_MODEL_CHANGES=true DIFF_SELECT=fct_example+ run_script)
+assert_contains "$SCHEMA_DBT_CALL_LOG_CONTENTS" "ls --select fct_example+" "schema diff uses DIFF_SELECT"
+```
+
+Match the exact helper names already used in `tests/test_pr_schema_diff.sh` (e.g. the existing dbt-call-log variable and run helper). Read that file first and reuse its fixtures rather than inventing new ones.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bash tests/test_pr_schema_diff.sh`
+Expected: FAIL on the two new scenarios (script currently ignores both env vars).
+
+- [ ] **Step 3: Add the short-circuit + selection precedence to `scripts/pr_schema_diff.sh`**
+
+After the script's env setup, before its model-selection block, insert:
+
+```bash
+if [[ "${HAS_MODEL_CHANGES:-true}" == "false" ]]; then
+  echo "No dbt model changes detected in this PR. No models for schema diff."
+  exit 0
+fi
+```
+
+Replace its selection block (`:56-67`) with the same precedence as Task 1 Step 4 (`DIFF_SELECT` → `state:modified+` → all), preserving whatever downstream variable name the schema script already uses for the model list.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bash tests/test_pr_schema_diff.sh`
+Expected: PASS (existing scenarios still green — this is why the full suite is re-run).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/pr_schema_diff.sh tests/test_pr_schema_diff.sh
+git commit -m "fix(ci): schema diff honours git-diff scope; docs-only PRs skip the schema diff"
+```
+
+---
+
+## Manual Validation & Follow-ups (not code tasks)
+
+Requires a configured GCP deployment (prod dataset + artifacts bucket) — validate on real PRs.
+
+- **Docs-only PR** → no data-diff and no schema-diff comment; CI fast. Confirms Tasks 1 & 3.
+- **Model PR whose lineage has a (temporarily) failing test** → the data-diff comment still posts; the `dbt test` check is red but separate. Confirms Task 2.
+- **No-op refactor PR** (rename a CTE) → expect ~0 diff rows. If non-zero, investigate:
+  - **Drift (A):** confirm the build used `state:modified+ --defer` and that `--defer` to the prod dataset succeeds from the CI project (permissions). Silent defer failure ⇒ ancestors rebuilt from live sources ⇒ drift.
+  - **Nondeterminism (D):** `QUALIFY ROW_NUMBER()/DENSE_RANK()` with tie-prone `ORDER BY` can emit different rows each build. Add deterministic tiebreakers where found.
+- **Follow-up:** guard against stale-manifest over-selection — validate the downloaded prod manifest's dbt version/`metadata` against the CI dbt version in `ci_build.sh`; if incompatible, treat as no-state rather than letting `state:modified+` flag everything.
+
+## Self-Review
+
+- **Spec coverage:** Problem 1 (docs-only) → Task 1 (data diff) + Task 3 (schema diff) + env wiring. Problem 2 (test gate) → Task 2. Problem 3 (drift) → Manual Validation (already mitigated). Covered.
+- **Placeholder scan:** all steps contain concrete bash/YAML. Task 3's test intentionally defers to the *existing* helper names in `test_pr_schema_diff.sh` (read-first instruction) rather than duplicating fixtures — a deliberate DRY choice, not a placeholder.
+- **Type/name consistency:** `HAS_MODEL_CHANGES`, `DIFF_SELECT`, `CI_SELECT`, `CI_DEFER` used identically across `get_changed_models.sh` output, `ci.yml` env, and the three scripts. Harness filenames (`tests/test_pr_data_diff.sh`, `tests/test_ci_build.sh`, `tests/test_pr_schema_diff.sh`) are consistent between creation and lint-job wiring.
+- **Ordering:** Task 1 wires `$GITHUB_ENV` (prerequisite for Tasks 2 & 3's env reads). Task 3 depends only on that wiring, not on Task 2 — the two can be reviewed in either order after Task 1.

--- a/docs/superpowers/plans/2026-08-12-template-build-selection-parity.md
+++ b/docs/superpowers/plans/2026-08-12-template-build-selection-parity.md
@@ -1,0 +1,286 @@
+# Template Build-Selection Parity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the template build git-diff-scoped so build and diff use the same selector, by emitting `BUILD_SELECT`/`NEEDS_FALLBACK` from `get_changed_models.sh` and rewriting `ci_build.sh`'s build tiers.
+
+**Architecture:** Two tasks. Task 1 (producer): `get_changed_models.sh` tracks model/seed/snapshot nodes and emits `BUILD_SELECT` (= `DIFF_SELECT`) and `NEEDS_FALLBACK`, self-exported to `$GITHUB_ENV`. Task 2 (consumer): `ci_build.sh` builds git-diff-scoped (`BUILD_SELECT` + `--defer`), falling back to `state:modified+` only for macro/config/yaml-only changes, and only when a prod manifest exists.
+
+**Tech Stack:** GitHub Actions, bash, dbt-core 1.10.8 / dbt-bigquery 1.10.1, BigQuery. Dependency-free shell test harnesses (bash 4+, coreutils, real throwaway git repos), same pattern as the existing `tests/test_get_changed_models.sh` / `tests/test_ci_build.sh`.
+
+## Global Constraints
+
+- dbt-core **1.10.8** / dbt-bigquery **1.10.1** — no flags newer than 1.10. `--exclude-resource-type test` and space-unioned `--select "a+ state:modified+"` are valid at this floor.
+- Shell tests dependency-free: bash 4+, coreutils only; stub `dbt`/`gsutil` on `PATH`; do **not** use `set -e` in the harness; build real throwaway git repos for `get_changed_models` fixtures.
+- Template repo only (`dbt-core-gcloud-template`). Do **not** modify `macros/compare_dev_prod.sql`, `scripts/compare_template.sql`, `scripts/pr_data_diff.sh`, or `scripts/pr_schema_diff.sh`.
+- Preserve `ci_build.sh`'s `--exclude-resource-type test` on every build and the `export_ci_select_defer` / `CI_SELECT` / `CI_DEFER` contract (consumed by the non-blocking `dbt test` step).
+- Commit messages neutral, conventional-commit; no co-author or AI-assistant trailers.
+- Emitted `BUILD_SELECT` and `DIFF_SELECT` are **identical** values (`name+` per changed node).
+
+---
+
+### Task 1: `get_changed_models.sh` emits `BUILD_SELECT` + `NEEDS_FALLBACK`
+
+**Files:**
+- Modify: `scripts/get_changed_models.sh` (detection loop + derivation + emit/export, ~lines 21-64)
+- Modify: `tests/test_get_changed_models.sh` (add/adjust scenarios)
+
+**Interfaces:**
+- Produces (stdout + `$GITHUB_ENV`): `HAS_MODEL_CHANGES`, `DIFF_SELECT`, **`BUILD_SELECT`** (= `DIFF_SELECT`), **`NEEDS_FALLBACK`**; plus `CHANGED_MODELS` (now = all changed buildable node names) to stdout/`$GITHUB_OUTPUT`.
+- `BUILD_SELECT`/`DIFF_SELECT` = space-separated `name+` for each changed model `.sql` / seed `.csv` / snapshot `.sql`. Empty for docs-only or macro/config-only changes.
+- `NEEDS_FALLBACK=true` iff a `macros/**/*.sql` or `dbt_project.yml`/`packages.yml` changed, OR a `models/**/*.yml`/`*.yaml` changed with no node in `CHANGED_MODELS`.
+
+- [ ] **Step 1: Update the tests to assert the new outputs (RED)**
+
+In `tests/test_get_changed_models.sh`, keep the existing helper/fixtures (real throwaway git repo per scenario). Add/adjust scenarios so each asserts on the script's emitted `BUILD_SELECT=`/`NEEDS_FALLBACK=`/`DIFF_SELECT=` lines:
+
+```bash
+echo "scenario: one model .sql → BUILD_SELECT=name+, DIFF_SELECT=name+, NEEDS_FALLBACK=false"
+# commit base, then add models/marts/fct_a.sql on the branch; run script
+assert_contains "$RUN_OUT" "BUILD_SELECT=fct_a+"
+assert_contains "$RUN_OUT" "DIFF_SELECT=fct_a+"
+assert_contains "$RUN_OUT" "NEEDS_FALLBACK=false"
+
+echo "scenario: seed .csv → BUILD_SELECT/DIFF_SELECT include seed+"
+# add seeds/my_seed.csv
+assert_contains "$RUN_OUT" "BUILD_SELECT=my_seed+"
+assert_contains "$RUN_OUT" "NEEDS_FALLBACK=false"
+
+echo "scenario: snapshot .sql → include snap+"
+# add snapshots/snap_a.sql
+assert_contains "$RUN_OUT" "BUILD_SELECT=snap_a+"
+
+echo "scenario: macro-only → NEEDS_FALLBACK=true, BUILD_SELECT empty, HAS_MODEL_CHANGES=true"
+# add macros/my_macro.sql
+assert_contains "$RUN_OUT" "HAS_MODEL_CHANGES=true"
+assert_contains "$RUN_OUT" "NEEDS_FALLBACK=true"
+assert_contains "$RUN_OUT" "BUILD_SELECT="     # empty value → line is exactly 'BUILD_SELECT='
+assert_not_contains "$RUN_ENV" "BUILD_SELECT=."  # no non-empty token exported
+
+echo "scenario: dbt_project.yml-only → NEEDS_FALLBACK=true, BUILD_SELECT empty"
+assert_contains "$RUN_OUT" "NEEDS_FALLBACK=true"
+
+echo "scenario: models/*.yml-only (no sql) → NEEDS_FALLBACK=true, BUILD_SELECT empty"
+# add models/marts/schema.yml only
+assert_contains "$RUN_OUT" "NEEDS_FALLBACK=true"
+
+echo "scenario: macro + model together → NEEDS_FALLBACK=true, BUILD_SELECT=name+"
+# add macros/m.sql AND models/marts/fct_a.sql
+assert_contains "$RUN_OUT" "NEEDS_FALLBACK=true"
+assert_contains "$RUN_OUT" "BUILD_SELECT=fct_a+"
+
+echo "scenario: docs-only (README) → all empty, HAS_MODEL_CHANGES=false"
+assert_contains "$RUN_OUT" "HAS_MODEL_CHANGES=false"
+assert_contains "$RUN_OUT" "NEEDS_FALLBACK=false"
+```
+
+Use the file's existing runner (the variable it captures stdout into, and the `$GITHUB_ENV` capture) — read the current file first and reuse its exact helper names; the snippet above uses `RUN_OUT`/`RUN_ENV` as placeholders for whatever the harness already uses.
+
+- [ ] **Step 2: Run to confirm RED**
+
+Run: `bash tests/test_get_changed_models.sh`
+Expected: FAIL on the new `BUILD_SELECT`/`NEEDS_FALLBACK` assertions (script emits neither today).
+
+- [ ] **Step 3: Rewrite the detection + derivation block in `scripts/get_changed_models.sh`**
+
+Replace the detection loop and DIFF_SELECT derivation (current lines ~21-48) with:
+
+```bash
+# Categorize changed files; collect buildable node names (models, seeds, snapshots).
+HAS_MODEL_CHANGES=false
+CHANGED_NODES=""
+MACRO_OR_CONFIG=false
+YAML_CHANGED=false
+
+while IFS= read -r file; do
+  [[ -z "$file" ]] && continue
+  case "$file" in
+    models/*.sql)
+      HAS_MODEL_CHANGES=true
+      CHANGED_NODES="${CHANGED_NODES} $(basename "$file" .sql)" ;;
+    seeds/*.csv)
+      HAS_MODEL_CHANGES=true
+      CHANGED_NODES="${CHANGED_NODES} $(basename "$file" .csv)" ;;
+    snapshots/*.sql)
+      HAS_MODEL_CHANGES=true
+      CHANGED_NODES="${CHANGED_NODES} $(basename "$file" .sql)" ;;
+    models/*.yml|models/*.yaml)
+      HAS_MODEL_CHANGES=true
+      YAML_CHANGED=true ;;
+    macros/*.sql|dbt_project.yml|packages.yml)
+      HAS_MODEL_CHANGES=true
+      MACRO_OR_CONFIG=true ;;
+  esac
+done <<< "$CHANGED_FILES"
+
+CHANGED_NODES=$(echo "$CHANGED_NODES" | xargs)  # trim/normalize whitespace
+
+# BUILD_SELECT == DIFF_SELECT: one 'name+' token per changed node (model + downstream;
+# no leading '+' so unchanged ancestors defer to prod). Empty for docs/macro/config-only.
+BUILD_SELECT=""
+for node in ${CHANGED_NODES}; do
+  BUILD_SELECT="${BUILD_SELECT} ${node}+"
+done
+BUILD_SELECT=$(echo "$BUILD_SELECT" | xargs)
+DIFF_SELECT="$BUILD_SELECT"
+
+# Fallback needed when a change can't be scoped by filename: macros/config affect any model;
+# a yaml-only change (no node) can alter tests/configs on any model.
+NEEDS_FALLBACK=false
+if [[ "$MACRO_OR_CONFIG" == "true" ]]; then NEEDS_FALLBACK=true; fi
+if [[ "$YAML_CHANGED" == "true" && -z "$CHANGED_NODES" ]]; then NEEDS_FALLBACK=true; fi
+```
+
+- [ ] **Step 4: Update the emit + export block**
+
+Replace the emit/export block (current lines ~50-64) with:
+
+```bash
+echo ""
+echo "HAS_MODEL_CHANGES=${HAS_MODEL_CHANGES}"
+echo "CHANGED_MODELS=${CHANGED_NODES:-<none>}"
+echo "DIFF_SELECT=${DIFF_SELECT:-<none>}"
+echo "BUILD_SELECT=${BUILD_SELECT:-<none>}"
+echo "NEEDS_FALLBACK=${NEEDS_FALLBACK}"
+
+if [[ -n "${GITHUB_ENV:-}" ]]; then
+  echo "HAS_MODEL_CHANGES=${HAS_MODEL_CHANGES}" >> "$GITHUB_ENV"
+  echo "DIFF_SELECT=${DIFF_SELECT}" >> "$GITHUB_ENV"
+  echo "BUILD_SELECT=${BUILD_SELECT}" >> "$GITHUB_ENV"
+  echo "NEEDS_FALLBACK=${NEEDS_FALLBACK}" >> "$GITHUB_ENV"
+fi
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  echo "has_model_changes=${HAS_MODEL_CHANGES}" >> "$GITHUB_OUTPUT"
+  echo "changed_models=${CHANGED_NODES}" >> "$GITHUB_OUTPUT"
+  echo "diff_select=${DIFF_SELECT}" >> "$GITHUB_OUTPUT"
+  echo "build_select=${BUILD_SELECT}" >> "$GITHUB_OUTPUT"
+  echo "needs_fallback=${NEEDS_FALLBACK}" >> "$GITHUB_OUTPUT"
+fi
+```
+
+Also update the header comment (lines ~4-9) to list the new outputs.
+
+- [ ] **Step 5: Run to confirm GREEN**
+
+Run: `bash tests/test_get_changed_models.sh`
+Expected: PASS (all scenarios). Also run `bash tests/test_pr_data_diff.sh` and `bash tests/test_pr_schema_diff.sh` — still green (DIFF_SELECT value shape unchanged for model-only cases).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/get_changed_models.sh tests/test_get_changed_models.sh
+git commit -m "feat(ci): emit BUILD_SELECT and NEEDS_FALLBACK from get_changed_models (git-diff build scope)"
+```
+
+---
+
+### Task 2: `ci_build.sh` git-diff-scoped build tiers
+
+**Files:**
+- Modify: `scripts/ci_build.sh` (build-strategy block, current lines ~66-104, + header comment)
+- Modify: `tests/test_ci_build.sh` (add tier scenarios)
+
+**Interfaces:**
+- Consumes (env): `HAS_MODEL_CHANGES`, `HAS_STATE` (internal), `BUILD_SELECT`, `NEEDS_FALLBACK`.
+- Preserves: `--exclude-resource-type test` on every build; `export_ci_select_defer` at the end; `CI_SELECT`/`CI_DEFER` semantics.
+
+- [ ] **Step 1: Add tier scenarios to `tests/test_ci_build.sh` (RED)**
+
+Reuse the file's existing `dbt`-stub-arg-log harness. Add:
+
+```bash
+echo "scenario: HAS_STATE + no fallback + BUILD_SELECT → git-diff scoped build"
+# stub gsutil+python so HAS_STATE=true (valid manifest); env: HAS_MODEL_CHANGES=true NEEDS_FALLBACK=false BUILD_SELECT="fct_a+"
+assert_contains "$(cat "$DBT_CALL_LOG")" 'build --target ci --select fct_a+ --defer --state prod_state --exclude-resource-type test'
+
+echo "scenario: HAS_STATE + fallback + BUILD_SELECT → combined select"
+# env: NEEDS_FALLBACK=true BUILD_SELECT="fct_a+"
+assert_contains "$(cat "$DBT_CALL_LOG")" 'build --target ci --select fct_a+ state:modified+ --defer --state prod_state --exclude-resource-type test'
+
+echo "scenario: HAS_STATE + fallback + no BUILD_SELECT → state:modified+ only"
+# env: NEEDS_FALLBACK=true BUILD_SELECT=""
+assert_contains "$(cat "$DBT_CALL_LOG")" 'build --target ci --select state:modified+ --defer --state prod_state --exclude-resource-type test'
+
+echo "scenario: no manifest (HAS_STATE false) → full build, no defer"
+# stub gsutil to fail → no manifest; env: HAS_MODEL_CHANGES=true BUILD_SELECT="fct_a+"
+assert_contains "$(cat "$DBT_CALL_LOG")" 'build --target ci --exclude-resource-type test'
+assert_not_contains "$(cat "$DBT_CALL_LOG")" '--defer'
+```
+
+Match the harness's real stub setup for the `HAS_STATE=true` case (it must produce a valid `prod_state/manifest.json` — the harness likely already stubs `gsutil`/`python3`; reuse it). Read the current file first.
+
+- [ ] **Step 2: Run to confirm RED**
+
+Run: `bash tests/test_ci_build.sh`
+Expected: FAIL (current script emits `state:modified+` for the scoped case, never `--select fct_a+`).
+
+- [ ] **Step 3: Rewrite the build-strategy block in `scripts/ci_build.sh`**
+
+Replace lines from `# Tier 1: No model changes → parse only` (~68) through the closing `fi` of the build strategy (~104) with:
+
+```bash
+# No dbt model changes → parse only (docs-only)
+if [[ "${HAS_MODEL_CHANGES:-true}" == "false" ]]; then
+  echo "No dbt model changes detected in this PR. Running parse-only validation."
+  dbt parse --target ci
+  echo ""
+  echo "=== Parse Complete (no model changes) ==="
+  exit 0
+fi
+
+if [[ "${HAS_STATE}" != "true" ]]; then
+  # No prod manifest → cannot defer safely → full build.
+  echo "No production state available, running full build"
+  dbt build --target ci --exclude-resource-type test
+  CI_SELECT=""; CI_DEFER=""
+elif [[ "${NEEDS_FALLBACK:-false}" == "false" && -n "${BUILD_SELECT:-}" ]]; then
+  # Git-diff scoped build; unchanged ancestors defer to prod (build scope == diff scope).
+  echo "Strategy: git-diff scoped build — ${BUILD_SELECT}"
+  dbt build --target ci --select "${BUILD_SELECT}" --defer --state prod_state --exclude-resource-type test
+  CI_SELECT="${BUILD_SELECT}"; CI_DEFER="--defer --state prod_state"
+elif [[ "${NEEDS_FALLBACK:-false}" == "true" && -n "${BUILD_SELECT:-}" ]]; then
+  # Macro/config change alongside model changes → union git scope with state:modified+.
+  SEL="${BUILD_SELECT} state:modified+"
+  echo "Strategy: git-diff + state:modified+ combined — ${SEL}"
+  dbt build --target ci --select "${SEL}" --defer --state prod_state --exclude-resource-type test
+  CI_SELECT="${SEL}"; CI_DEFER="--defer --state prod_state"
+else
+  # Macro/config/yaml-only change (no scoped node) → state comparison.
+  echo "Strategy: state:modified+ fallback (macro/config/YAML-only change)"
+  dbt build --target ci --select "state:modified+" --defer --state prod_state --exclude-resource-type test
+  CI_SELECT="state:modified+"; CI_DEFER="--defer --state prod_state"
+fi
+
+echo ""
+echo "=== Build Complete ==="
+
+export_ci_select_defer
+```
+
+Update the header comment block (lines ~4-17) to describe the git-diff-scoped strategy (git-diff scope with defer; combined fallback for macro/config; full build only when no manifest) while keeping the `--exclude-resource-type test` / `CI_SELECT`/`CI_DEFER` note.
+
+- [ ] **Step 4: Run to confirm GREEN**
+
+Run: `bash tests/test_ci_build.sh`
+Expected: PASS. Then run all four suites: `for t in test_get_changed_models test_pr_data_diff test_ci_build test_pr_schema_diff; do bash tests/$t.sh; done` — all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/ci_build.sh tests/test_ci_build.sh
+git commit -m "feat(ci): git-diff-scoped build in ci_build.sh (BUILD_SELECT + defer; state:modified+ fallback)"
+```
+
+---
+
+## Manual Validation & Follow-ups (not code tasks)
+
+- After merge, a weightcare-style validation confirms end-to-end behavior on real GCP (shell tests only prove command construction): a model-change PR should build+diff the same scoped set; a macro-change PR should hit the `state:modified+` fallback.
+- Known limitations carried from the spec (documented, not fixed here): macro+model PRs build ⊋ diff; fallback path still manifest-dependent; no-manifest → full build.
+
+## Self-Review
+
+- **Spec coverage:** `BUILD_SELECT`/`NEEDS_FALLBACK` emission + seed/snapshot tracking → Task 1. Git-diff-scoped `ci_build.sh` tiers + no-manifest→full-build deviation → Task 2. Both covered.
+- **Placeholder scan:** concrete bash + assertions throughout; the `RUN_OUT`/`DBT_CALL_LOG` names are explicitly flagged to be reconciled with each harness's existing helpers (read-first), not invented.
+- **Type/name consistency:** `BUILD_SELECT`, `DIFF_SELECT`, `NEEDS_FALLBACK`, `CHANGED_NODES`, `HAS_STATE`, `CI_SELECT`, `CI_DEFER` used identically across Task 1's emission and Task 2's consumption. `BUILD_SELECT == DIFF_SELECT` holds in both tasks.
+- **Ordering:** Task 1 produces the env vars Task 2 consumes; Task 2 depends on Task 1.

--- a/docs/superpowers/specs/2026-07-27-pr-schema-diff-set-u-fix-design.md
+++ b/docs/superpowers/specs/2026-07-27-pr-schema-diff-set-u-fix-design.md
@@ -1,0 +1,223 @@
+# Design: Repair `pr_schema_diff.sh` (issue #53 + silent no-op)
+
+**Date:** 2026-07-27
+**Issue:** [#53](https://github.com/domainmethods/dbt-core-gcloud-template/issues/53)
+**Status:** Approved for planning
+
+## Summary
+
+`scripts/pr_schema_diff.sh` has two independent defects. Issue #53 makes it abort
+the CI job outright. A second, previously unreported defect makes the feature a
+silent no-op even when it does not abort. This design fixes both, adds the
+repository's first shell test harness, and defers a performance concern to a
+measured follow-up.
+
+## Problem
+
+### Defect A — uninitialized array aborts CI (issue #53)
+
+Line 336 declares the orphan accumulator as `declare -a orphans` with no
+initializer. Line 353 then reads `${#orphans[@]}`. Under `set -u`, reading
+`${#arr[@]}` on a declared-but-unassigned array is an unbound-variable error and
+the script exits 1. This is *not* fixed by bash 4.4's array relaxation, which
+covers `${arr[@]}` but not `${#arr[@]}`.
+
+`orphans` is only ever assigned inside the `orphans+=(...)` branch, so the script
+survives only when at least one orphan is found. The failure mode is inverted: a
+clean production dataset fails CI, a messy one passes.
+
+The schema-diff step in `.github/workflows/ci.yml` (line 115-117) has no
+`continue-on-error`, unlike the docs and artifact-upload steps around it, so a
+non-zero exit fails the entire PR build.
+
+Reproduced against the current script with stubbed `bq`/`dbt`:
+
+| Scenario | Exit | Cause |
+|---|---|---|
+| Zero orphans (all prod tables covered by manifest) | 1 | `orphans` never assigned |
+| Prod dataset unreadable (Access Denied) | 1 | `continue` before assignment |
+| At least one orphan exists | 0 | array assigned |
+| `bq` emits a non-JSON banner | 1 | jq parse error before assignment |
+
+### Defect B — the per-model diff never runs
+
+`get_node_by_name` (lines 76-83) binds `local manifest=$1` but never passes
+`"$manifest"` to `jq`. With no file argument, `jq` reads standard input, which is
+empty or closed under CI, and returns nothing.
+
+That function is the gate at the top of the per-model loop. When it returns
+empty, the loop logs `[warn] Could not resolve model X in PR manifest; skipping`
+and `continue`s. Every model therefore skips, the markdown summary table is
+emitted with a header and no rows, and the PR comment is empty.
+
+`get_node_by_uid`, directly below it, does pass `"$manifest"` correctly — the
+omission is isolated to `get_node_by_name`.
+
+Confirmed two ways: direct isolation of the function against a fixture manifest,
+and the CI log for downstream `weightcare-pipeline-new` PR #72, where all 40
+selected models emit the skip warning and no diff content is produced.
+
+### Downstream state
+
+`jasonbhart/weightcare-pipeline-new` already carries a fix for Defect A
+(`declare -a orphans=()` plus a subshell wrapper). It does **not** have a fix for
+Defect B. It has also regressed two things this design keeps: the
+`--maximum_bytes_billed` cost cap on `bq_json`, and the
+`[warn] Could not list tables in ...` diagnostic written to `orphans.md`.
+
+## Non-goals
+
+- `DIFF_SELECT` git-diff model selection (issue #29).
+- `drop_bq_dataset.sh` unbound-variable defects (issue #19), though the test
+  harness introduced here is intended to be reusable for it.
+- Query batching (see Deferred work).
+- Any change to `pr_data_diff.sh`.
+
+## Design
+
+### 1. Fix `get_node_by_name`
+
+Pass the manifest path to `jq` and drop the unused `name` local, which shadows
+nothing and is never read (the body uses `$2` directly).
+
+```bash
+get_node_by_name() {
+  local manifest=$1
+  jq -r --arg n "$2" '
+    .nodes
+    | to_entries[]
+    | select(.value.resource_type=="model" and .value.name==$n)
+    | .value' "$manifest"
+}
+```
+
+This is the change that makes the feature functional. Everything downstream of it
+in the loop executes for the first time.
+
+### 2. Harden the newly reachable per-model path
+
+Fixing Defect B activates code that has never executed. The specific hazard is
+`compute_column_diff` and `compute_meta_diff`, which pass introspection results to
+`jq --argjson`. `--argjson` hard-fails on input that is not valid JSON, and the
+six `bq_*` helpers can return banner text or an error string rather than JSON.
+Under `set -e` that aborts the script.
+
+Add a single normalizing helper and route all six introspection results through
+it, so non-JSON degrades to an empty array instead of aborting:
+
+```bash
+as_json_array() {
+  local v=${1:-}
+  if [[ -n "$v" ]] && printf '%s' "$v" | jq -e 'type=="array"' >/dev/null 2>&1; then
+    printf '%s' "$v"
+  else
+    printf '[]'
+  fi
+}
+```
+
+### 3. Fix the orphan block (issue #53)
+
+Port the shape downstream validated, with the two downstream regressions
+corrected:
+
+- `declare -a orphans=()` — explicitly initialized.
+- Capture the `jq` table-name parse into a variable guarded with `|| true` plus an
+  emptiness check, and feed the `while` loop from a `<<<` herestring rather than a
+  `< <(echo ... | jq ...)` process substitution.
+- Wrap the whole block in `( set +euo pipefail; ... ) || echo "[warn] ..." >&2` so
+  this best-effort side feature can never abort the core diff.
+- Delete the dead `tables_json=$(bq_table_type "$PROD_PROJECT" "$ds" "__all__")`
+  call at line 338. Its result is never read and it issues a real BigQuery query
+  on every run.
+- **Keep** `--maximum_bytes_billed=1000000000` on `bq_json`.
+- **Keep** the `[warn] Could not list tables in $PROD_PROJECT.$ds (no access?)`
+  line written into `orphans.md`, so an unreadable dataset stays visible in the
+  report rather than silently producing "Found 0 orphan(s)".
+
+The subshell deliberately trades loud-wrong for quiet-wrong inside the orphan
+block. That is acceptable because the block is a side report; it is not acceptable
+for the per-model diff, which is why item 2 guards rather than suppresses.
+
+### 4. Harden the CI step
+
+Add `continue-on-error: true` to the "Generate schema diffs for changed models"
+step in `.github/workflows/ci.yml`, matching the docs-generate and
+artifact-upload steps. This is defence in depth: item 3 prevents the known
+failure, this prevents the class.
+
+### 5. Test harness
+
+New file `tests/test_pr_schema_diff.sh` — dependency-free bash, no bats, no new CI
+dependency. It builds a temp directory containing:
+
+- executable `bq` and `dbt` stubs placed first on `PATH`, with per-scenario
+  behaviour selected by an environment variable;
+- fixture `target/manifest.json` and `prod_state/manifest.json`;
+- an invocation counter file that the `bq` stub appends to on every call.
+
+Scenarios and assertions, all run with stdin closed to mimic CI:
+
+| # | Scenario | Assertion |
+|---|---|---|
+| 1 | Zero orphans | exit 0 |
+| 2 | Prod dataset unreadable | exit 0, `orphans.md` contains the "Could not list tables" warning |
+| 3 | One orphan present | exit 0, `orphans.md` lists it |
+| 4 | `bq` returns a non-JSON banner | exit 0, no `jq` parse abort |
+| 5 | **Regression guard for Defect B** | summary table has one row per selected model and no `Could not resolve model` warning |
+| 6 | Non-JSON introspection output | exit 0, model row still emitted with a degraded status |
+
+Scenario 5 is the assertion that locks in the fix for Defect B, and is the one
+that would have caught the no-op in the first place.
+
+The harness also prints the recorded `bq` invocation count. That converts the
+performance risk below into a measured number without touching real BigQuery.
+
+Wiring: a `test-scripts` target in the `Makefile` (added to `.PHONY`) and a step in
+the CI `lint` job, which is fast and has no GCP dependency.
+
+## Deferred work
+
+Today the per-model loop `continue`s before issuing any `bq` call, so it performs
+**zero** BigQuery queries. Fixing Defect B activates six `bq` invocations per
+model — columns, table type, and table options, for dev and prod each. At
+downstream's 40-model selection that is roughly 240 `bq` CLI invocations, each a
+fresh Python process and API round trip. Against a job already running ~17
+minutes, this could add materially to CI wall-clock.
+
+The structural answer is to batch: issue one `INFORMATION_SCHEMA.COLUMNS`, one
+`.TABLES`, and one `.TABLE_OPTIONS` query per dataset, cache the results in
+memory, and filter per model. That reduces the count from `6 × models` to roughly
+`3 × datasets`.
+
+Batching is **out of scope for this change**. It is a larger diff touching every
+query helper, and the decision should rest on a measured number rather than an
+estimate. This change ships the correctness fixes and the instrumentation; the
+`bq` invocation count from the harness, plus the first real CI run, decide whether
+batching is warranted as a follow-up.
+
+## Rollout
+
+1. Upstream template: single PR carrying items 1-5, closing issue #53.
+2. File a separate upstream issue for Defect B, cross-referencing #53, with the
+   evidence recorded here.
+3. Downstream `weightcare-pipeline-new`: a separate PR carrying only items 1 and
+   2, since it already has item 3. It is a private production repository, so this
+   is prepared for review rather than merged unilaterally.
+
+## Risks
+
+- The template repository's own CI is currently red across all recent runs, so it
+  cannot serve as a verification signal. Local stub tests are the only feedback
+  loop available before merge.
+- Stub tests verify control flow, not SQL correctness. They prove the script does
+  not crash and does produce rows; they cannot prove the diff is semantically
+  right.
+- Activating a never-executed code path may surface further defects in the
+  `NEW_MODEL` and `AUTH_ERROR` status logic. If that happens, the follow-ups are
+  filed as issues rather than absorbed into this change.
+- PR comments change from an empty table to a populated one. This is the intended
+  behaviour but is a visible change for existing users.
+- `mapfile` requires bash 4+, so stock macOS bash 3.2 cannot run the script. CI is
+  ubuntu with bash 5, and local developers use a modern bash, so this is recorded
+  rather than addressed.

--- a/docs/superpowers/specs/2026-07-27-pr-schema-diff-set-u-fix-design.md
+++ b/docs/superpowers/specs/2026-07-27-pr-schema-diff-set-u-fix-design.md
@@ -102,8 +102,8 @@ Fixing Defect B activates code that has never executed. The specific hazard is
 six `bq_*` helpers can return banner text or an error string rather than JSON.
 Under `set -e` that aborts the script.
 
-Add a single normalizing helper and route all six introspection results through
-it, so non-JSON degrades to an empty array instead of aborting:
+Add a single normalizing helper so non-JSON degrades to an empty array instead of
+aborting:
 
 ```bash
 as_json_array() {
@@ -115,6 +115,31 @@ as_json_array() {
   fi
 }
 ```
+
+**Ordering rule — classify from raw, normalize at the jq boundary.** The
+introspection results are both a *signal* and a *payload*. Line 255 classifies
+status by inspecting the raw string:
+
+```bash
+if [[ -z "$prod_cols_json" || "$prod_cols_json" == *"Access Denied"* ]]; then
+    status="AUTH_ERROR"
+```
+
+Normalizing before this check would rewrite `Access Denied` to `[]`, which is
+non-empty and no longer matches the substring, silently downgrading a permissions
+failure to a clean `OK` diff. `as_json_array` must therefore be applied **only**
+where a value is handed to `jq --argjson`, never before status classification.
+
+Status classification is extended to cover the third case, which currently has no
+representation:
+
+- empty or `Access Denied` → `AUTH_ERROR` (unchanged)
+- non-empty but not parseable as a JSON array → `NON_JSON` (new)
+- parseable, but no prod table type → `NEW_MODEL` (unchanged)
+- otherwise → `OK` (unchanged)
+
+`NON_JSON` rows are emitted in the summary table with zero column counts. The
+requirement is that unparseable introspection output is never reported as `OK`.
 
 ### 3. Fix the orphan block (issue #53)
 
@@ -164,11 +189,20 @@ Scenarios and assertions, all run with stdin closed to mimic CI:
 | 2 | Prod dataset unreadable | exit 0, `orphans.md` contains the "Could not list tables" warning |
 | 3 | One orphan present | exit 0, `orphans.md` lists it |
 | 4 | `bq` returns a non-JSON banner | exit 0, no `jq` parse abort |
-| 5 | **Regression guard for Defect B** | summary table has one row per selected model and no `Could not resolve model` warning |
-| 6 | Non-JSON introspection output | exit 0, model row still emitted with a degraded status |
+| 5 | **Regression guard for Defect B** | see below |
+| 6 | Non-JSON introspection output | exit 0, and status is **not** `OK` |
 
-Scenario 5 is the assertion that locks in the fix for Defect B, and is the one
-that would have caught the no-op in the first place.
+**Scenario 5, stated precisely.** For every model returned by `dbt ls`, the run
+must emit exactly one row in `schema-summary.md` and zero
+`Could not resolve model` warnings. Models with no prod counterpart — the common
+case on a template's first run — count as satisfying the row requirement with
+status `NEW_MODEL`; the assertion is on row *count* and warning *absence*, not on
+status value. This is the assertion that locks in the fix for Defect B and is the
+one that would have caught the no-op in the first place.
+
+**Scenario 6** asserts only that the run survives and does not misreport
+unparseable output as `OK`. The exact status string is pinned during
+implementation, once the behaviour is observed rather than predicted.
 
 The harness also prints the recorded `bq` invocation count. That converts the
 performance risk below into a measured number without touching real BigQuery.
@@ -196,20 +230,53 @@ estimate. This change ships the correctness fixes and the instrumentation; the
 `bq` invocation count from the harness, plus the first real CI run, decide whether
 batching is warranted as a follow-up.
 
-## Rollout
+## Validation and rollout
 
-1. Upstream template: single PR carrying items 1-5, closing issue #53.
-2. File a separate upstream issue for Defect B, cross-referencing #53, with the
+Validation runs downstream-first. This template repository has only two example
+models and its own CI is red, so it cannot confirm that the Defect B fix works at
+realistic scale. `weightcare-pipeline-new` has green CI and roughly 40 real
+models, and already carries the item 3 fix, so it isolates Defect B cleanly.
+
+**Tier 1 — stub fixtures, local, free.** The `tests/test_pr_schema_diff.sh`
+harness described above, run against synthetic manifests.
+
+**Tier 2 — real manifest, local, free.** Clone `weightcare-pipeline-new`, generate
+its manifest offline with `dbt parse` (no warehouse connection required), and run
+the fixed script against roughly 40 real models with the counting `bq` stub. This
+tier is the substantive one: it proves the Defect B fix against a manifest shaped
+like production, and it produces the true `bq` invocation count that decides the
+batching question. No credentials, no spend, no production impact.
+
+**Tier 3 — real CI, costs money, requires authorization.** A draft PR on
+`weightcare-pipeline-new` triggering its `bigquery-ci` job end to end. This is the
+only tier that exercises real BigQuery introspection and the only one that
+measures true wall-clock. It runs against a production GCP project and is visible
+to the repository owner. Access is push, not admin. **This tier is not initiated
+without explicit approval, and nothing is merged downstream unilaterally.**
+
+Rollout order:
+
+1. Implement items 1-5 on a branch. Tier 1 and Tier 2 must pass.
+2. Tier 3, if authorized. Record the measured query count and wall-clock.
+3. Upstream template PR carrying items 1-5, closing issue #53, citing the Tier 2
+   and Tier 3 results.
+4. File a separate upstream issue for Defect B, cross-referencing #53, with the
    evidence recorded here.
-3. Downstream `weightcare-pipeline-new`: a separate PR carrying only items 1 and
-   2, since it already has item 3. It is a private production repository, so this
-   is prepared for review rather than merged unilaterally.
+5. Downstream PR carrying items 1 and 2 only, opened for the owner's review.
+
+Nothing is committed to the upstream default branch before Tier 2 passes.
 
 ## Risks
 
 - The template repository's own CI is currently red across all recent runs, so it
-  cannot serve as a verification signal. Local stub tests are the only feedback
-  loop available before merge.
+  cannot serve as a verification signal. This is the reason validation is
+  downstream-first; without Tier 2 there would be no realistic feedback loop
+  before merge.
+- Tier 2 uses a manifest produced by `dbt parse` rather than the `dbt docs
+  generate` manifest CI actually consumes. If the two differ in a way that
+  matters to `get_node_by_name`, Tier 2 could pass while CI still fails. The
+  fields in question (`name`, `alias`, `schema`, `database`, `unique_id`) are
+  parse-time attributes, so divergence is unlikely, but only Tier 3 rules it out.
 - Stub tests verify control flow, not SQL correctness. They prove the script does
   not crash and does produce rows; they cannot prove the diff is semantically
   right.

--- a/docs/superpowers/specs/2026-07-27-tier2-validation-results.md
+++ b/docs/superpowers/specs/2026-07-27-tier2-validation-results.md
@@ -1,0 +1,60 @@
+# Tier 2 Validation: `pr_schema_diff.sh` against a real downstream manifest
+
+**Date:** 2026-07-27
+**Branch:** `fix/53-pr-schema-diff-set-u`
+**Downstream repo:** `jasonbhart/weightcare-pipeline-new` (cloned read-only, depth 1, into a scratch temp dir; never pushed to, no branch/commit/PR created there)
+
+## Method
+
+1. Cloned `jasonbhart/weightcare-pipeline-new` (~16MB checkout) into a scratch temp directory.
+2. Created a Python venv, installed `dbt-core==1.10.8` / `dbt-bigquery==1.10.1` (the versions specified in the Task 5 brief), ran `dbt deps`.
+3. Ran `dbt parse` with `DBT_TARGET=ci` and dummy CI env vars. **`dbt parse` succeeded fully offline** — it never attempted a BigQuery connection, so the `dbt ls --output name` fallback was not needed. Produced `target/manifest.json` (7.6MB).
+4. Copied the real manifest into `target/manifest.json` and `prod_state/manifest.json` for a `$WORK/run` scratch harness, per the brief's stub scripts (`bq` stub logs every invocation and returns canned JSON by query shape; `dbt` stub serves `dbt ls` from the real manifest).
+5. Ran the fixed `scripts/pr_schema_diff.sh` unmodified against this harness, with `bq` and `dbt` fully stubbed (no GCP auth, no BigQuery spend).
+
+## Deviation from the brief: real model count is 383, not ~40
+
+The brief assumed "~40 real models." The manifest built from the actual repository contains:
+
+- **69** models owned by the `dbt_gcloud` project itself (`package_name == dbt_gcloud`)
+- **383** models total once installed packages are included (Fivetran `facebook_ads`/`hubspot`/`klaviyo`/`shopify`, `ga4`)
+
+The brief's `dbt` stub selects **every** `resource_type=="model"` node in the manifest regardless of package, which is also what the real script does in its fallback path (`dbt ls --resource-type model --output name --quiet`, used whenever there is no prod-manifest-based `state:modified+` selection). Since the harness intentionally exercises "no state filtering" behavior, this is a legitimate worst-case measurement, not a mistake — but it is 6-10x larger than the brief's planning assumption. Both scales are reported below.
+
+## New finding: `get_node_by_name` does not disambiguate by package
+
+While auditing the raw `bq` invocation log, the naive count (`wc -l < bq_calls.log`, as literally specified in the brief's Step 4) came to **2599**, not the expected `6 × 383 + 1 = 2299`. Root cause: **10 model names are duplicated across the project and an installed package** (e.g. `stg_facebook_ads__basic_ad_actions` exists both as the project's own customized model and inside the `fivetran/facebook_ads` package it shadows). `get_node_by_name()` in `scripts/pr_schema_diff.sh` selects on `.value.name==$n` only, with no `package_name` filter, so for these 10 names it matches **two** manifest nodes and pipes a two-document JSON stream through `node_to_fqn`. Downstream `jq -r .project`/`.dataset`/`.identifier` extraction then emits multi-line, corrupted FQN strings (visible directly in `stg_facebook_ads__basic_ad_actions.txt`: `Prod:` spans 4 lines instead of 1). This inflates the naive line-count of the `bq` call log by exactly 300 lines (confirmed: `grep -c -- '--project_id='` — a marker present exactly once per genuine invocation — gives the clean **2299**, matching the formula exactly).
+
+This is a real, previously-undetected defect that only surfaces at realistic scale (the 2-model test fixture has no name collisions across packages). It does **not** cause `unresolved > 0` (the model still resolves, just to corrupted data) so it does not trip the brief's stop condition, and per task boundaries `scripts/pr_schema_diff.sh` was not modified to fix it here. It should be filed as a follow-up defect (candidate "Defect C") alongside the already-known Defect B.
+
+## The four measured numbers (Step 4)
+
+| Metric | Value |
+|---|---|
+| Models selected (`dbt ls` over the real manifest, stubbed) | **383** |
+| Unresolved (`grep -c 'Could not resolve model' stdout.txt`) | **0** |
+| Summary rows (`grep -c '^\| [a-z]' schema-summary.md`) | **383** (equals models selected) |
+| `bq` invocations, true count (`--project_id=` marker, one per real call) | **2299** (= 6 × 383 + 1, exact match to formula) |
+| `bq` invocations, naive line count (`wc -l < bq_calls.log`, as literally specified in the brief) | 2599 (inflated by the package-name-collision defect above) |
+
+Script exit code: **0**. No BigQuery credentials were used; `bq` and `dbt` were fully stubbed shell scripts on `PATH`.
+
+## Extrapolated wall-clock and batching recommendation
+
+Using the true invocation count (2299) at an assumed 2-6 seconds per real `bq` invocation (typical for a small `INFORMATION_SCHEMA` query against BigQuery):
+
+- Low estimate: 2299 × 2s ≈ 4,598s ≈ **76.6 minutes**
+- High estimate: 2299 × 6s ≈ 13,794s ≈ **229.9 minutes (3.8 hours)**
+
+Even restricted to only the project's own 69 models (6 × 69 + 1 = 415 invocations, a more realistic ceiling for a single PR touching only its own code), the range is still 415 × 2-6s ≈ **13.8-41.5 minutes**.
+
+Both scales are far in excess of the brief's five-minute threshold.
+
+**Recommendation: batch the `INFORMATION_SCHEMA` queries.** At current per-model, per-query-type `bq` invocation volume, a PR that changes even a modest number of models (let alone triggers the full-manifest fallback path) will add tens of minutes to CI. Batching (e.g. one `INFORMATION_SCHEMA.COLUMNS`/`TABLE_OPTIONS`/`TABLES` query per dataset covering all target tables via `WHERE table_name IN (...)`, instead of one query per table per side) should be scoped as a follow-up task.
+
+## Cleanup and boundaries confirmation
+
+- The clone, venv, and scratch run directory were created entirely under a temp/scratchpad path and removed with `rm -rf` after this document was written.
+- No `bq` binary was ever invoked for real; `bq` was a stub shell script logging to a local file and returning canned JSON.
+- No commits, branches, PRs, or issues were created against `jasonbhart/weightcare-pipeline-new`; the clone was read-only.
+- `scripts/pr_schema_diff.sh`, `tests/test_pr_schema_diff.sh`, `Makefile`, and `.github/workflows/ci.yml` were not modified.

--- a/docs/superpowers/specs/2026-08-12-template-build-selection-parity-design.md
+++ b/docs/superpowers/specs/2026-08-12-template-build-selection-parity-design.md
@@ -1,0 +1,166 @@
+# Template Build-Selection Parity — Design
+
+**Date:** 2026-08-12
+**Status:** Approved (brainstorming) → pending implementation plan
+**Branch:** `fix/template-build-parity` (stacked on `fix/53-pr-schema-diff-set-u`)
+
+## Problem
+
+After the CI diff-accuracy work (PR #55), the template's **diff** selection is git-diff based
+(`DIFF_SELECT` → `state:modified+` → all) but its **build** selection in `scripts/ci_build.sh`
+is still purely `state:modified+` (manifest/state based). Two consequences:
+
+1. **Build and diff use different selectors.** In the common case they align, but when the prod
+   manifest is stale or version-mismatched, `state:modified+` over-selects (the "211-model"
+   symptom observed in the downstream weightcare validation) — the build over-builds, and in
+   edge cases can diverge from what the diff expects.
+2. **Manifest dependence for build scoping.** The template cannot scope the build from the git
+   diff alone; it always leans on the prod manifest.
+
+The downstream weightcare repo already solved this: it emits a git-diff `BUILD_SELECT` and builds
+git-diff-scoped, using `state:modified+` only as a fallback for changes that cannot be scoped by
+filename (macros, project config, yaml-only). This design ports that capability to the template.
+
+## Goal
+
+Make the template build **git-diff-scoped** so build and diff use the same selector for
+model-change PRs, removing manifest dependence for the common case. Achieve capability parity with
+weightcare's build strategy (not byte-for-byte code parity).
+
+## Non-goals (explicitly out of scope)
+
+- Changes to `pr_data_diff.sh` / `pr_schema_diff.sh` selection (the diff scripts stay as-is).
+- The data-diff sample-rows `EXCEPT DISTINCT`/`UNION ALL` set-operation bug in
+  `macros/compare_dev_prod.sql` (tracked separately).
+- Model non-determinism (`QUALIFY`/window ties) — a data-modeling issue in consumer repos, not the
+  template's CI.
+- A manifest-freshness/version-compat guard (a possible later enhancement; see Known Limitations).
+
+## Design
+
+### 1. `scripts/get_changed_models.sh` — emit `BUILD_SELECT` and `NEEDS_FALLBACK`
+
+Today the script sets `HAS_MODEL_CHANGES`, `CHANGED_MODELS` (model `.sql` basenames), and derives
+`DIFF_SELECT` (`name+` per changed model). Extend it:
+
+- **Track buildable names from three file types**, not just models:
+  - `models/**/*.sql` → model basename
+  - `seeds/**/*.csv` → seed basename
+  - `snapshots/**/*.sql` → snapshot basename
+  Collect these into one ordered, de-duplicated list `CHANGED_NODES`.
+- **`BUILD_SELECT`** = `name+ name+ …` over `CHANGED_NODES` (one `name+` token each; no leading `+`
+  so ancestors defer to prod).
+- **`DIFF_SELECT`** = the **same** value as `BUILD_SELECT`. (This widens today's model-only
+  `DIFF_SELECT` to also cover seed/snapshot changes — a wanted improvement: a seed change now diffs
+  its downstream models. Existing `DIFF_SELECT` tests are updated accordingly.)
+- **`NEEDS_FALLBACK`** = `true` when a change cannot be scoped from filenames alone:
+  - any `macros/**/*.sql` changed, OR
+  - `dbt_project.yml` or `packages.yml` changed, OR
+  - a `models/**/*.yml`/`*.yaml` changed with **no** accompanying model/seed/snapshot node in this PR
+    (yaml-only change — tests/configs can affect any model).
+  Otherwise `false`.
+- **`HAS_MODEL_CHANGES`** logic is unchanged (true if any dbt-relevant file changed).
+- **Self-export** `BUILD_SELECT` and `NEEDS_FALLBACK` to `$GITHUB_ENV` alongside the existing
+  `HAS_MODEL_CHANGES`/`DIFF_SELECT`, and to `$GITHUB_OUTPUT` alongside the existing outputs.
+
+Emitted keys after this change: `HAS_MODEL_CHANGES`, `CHANGED_MODELS`, `DIFF_SELECT`,
+`BUILD_SELECT`, `NEEDS_FALLBACK`.
+
+### 2. `scripts/ci_build.sh` — git-diff-scoped build tiers
+
+Keep the existing state-detection block (downloads the prod manifest, sets `HAS_STATE`, validates
+JSON) and the `--exclude-resource-type test` flag on every build, and the `CI_SELECT`/`CI_DEFER`
+export at the end (consumed by the non-blocking `dbt test` step). Replace the build-strategy
+selection with tiers gated first on "can we defer?" (`HAS_STATE`):
+
+```
+if HAS_MODEL_CHANGES == false:
+    dbt parse --target ci ; exit 0                      # docs-only
+
+if HAS_STATE == false:                                  # no prod manifest → can't defer
+    dbt build --target ci --exclude-resource-type test  # full build
+    CI_SELECT=""; CI_DEFER=""
+
+else (HAS_STATE == true):
+    if NEEDS_FALLBACK == false and BUILD_SELECT non-empty:            # git-diff scoped
+        dbt build --target ci --select "$BUILD_SELECT" \
+            --defer --state prod_state --exclude-resource-type test
+        CI_SELECT="$BUILD_SELECT"; CI_DEFER="--defer --state prod_state"
+    elif NEEDS_FALLBACK == true and BUILD_SELECT non-empty:           # combined (macro+model)
+        SEL="$BUILD_SELECT state:modified+"
+        dbt build --target ci --select "$SEL" \
+            --defer --state prod_state --exclude-resource-type test
+        CI_SELECT="$SEL"; CI_DEFER="--defer --state prod_state"
+    else:                                                            # macro/config/yaml-only
+        dbt build --target ci --select "state:modified+" \
+            --defer --state prod_state --exclude-resource-type test
+        CI_SELECT="state:modified+"; CI_DEFER="--defer --state prod_state"
+
+# end: export CI_SELECT / CI_DEFER to $GITHUB_ENV (guarded by [[ -n "${GITHUB_ENV:-}" ]])
+```
+
+Result: for a model-change PR (`NEEDS_FALLBACK=false`), the build selects the same `BUILD_SELECT`
+as the diff's `DIFF_SELECT`, deferring ancestors to prod — build and diff scopes match and neither
+depends on the manifest for scoping.
+
+### 3. Deviation from weightcare (intentional, for correctness)
+
+weightcare, when it has a `BUILD_SELECT` but **no** prod manifest, runs a *scoped* build with no
+`--defer` — which fails because unbuilt ancestors are missing. This design gates on `HAS_STATE`
+first, so **no manifest → full build** (the template's current safe behavior). This is
+parity-plus-one-fix, not a byte-for-byte copy.
+
+### 4. Data flow (shape unchanged)
+
+detect step (`get_changed_models.sh`) → `$GITHUB_ENV`
+(`HAS_MODEL_CHANGES`, `DIFF_SELECT`, **`BUILD_SELECT`**, **`NEEDS_FALLBACK`**) →
+`ci_build.sh` (git-diff-scoped build) → `CI_SELECT`/`CI_DEFER` → non-blocking `dbt test` + diffs.
+No `.github/workflows/ci.yml` change is required: `get_changed_models.sh` self-exports and
+`ci_build.sh` reads from the environment.
+
+## Testing
+
+Extend the two existing dependency-free harnesses (bash 4+/coreutils, real throwaway git-repo
+fixtures, no `set -e`):
+
+- **`tests/test_get_changed_models.sh`** — add/adjust scenarios asserting the new outputs:
+  - one model `.sql` → `BUILD_SELECT="name+"`, `DIFF_SELECT="name+"`, `NEEDS_FALLBACK=false`
+  - one seed `.csv` → `BUILD_SELECT`/`DIFF_SELECT` include `seed+`, `NEEDS_FALLBACK=false`
+  - one snapshot `.sql` → include `snap+`, `NEEDS_FALLBACK=false`
+  - macro-only → `NEEDS_FALLBACK=true`, `BUILD_SELECT` empty, `HAS_MODEL_CHANGES=true`
+  - `dbt_project.yml`-only → `NEEDS_FALLBACK=true`, `BUILD_SELECT` empty
+  - `models/**/*.yml`-only (no sql) → `NEEDS_FALLBACK=true`, `BUILD_SELECT` empty
+  - macro + model together → `NEEDS_FALLBACK=true`, `BUILD_SELECT="name+"`
+  - docs-only (README) → all empty, `HAS_MODEL_CHANGES=false`
+- **`tests/test_ci_build.sh`** — add one scenario per tier, asserting the exact `dbt build` command
+  via the stubbed-`dbt` arg log:
+  - `HAS_STATE=true`, `NEEDS_FALLBACK=false`, `BUILD_SELECT` set → `build --select "<BUILD_SELECT>" --defer --state prod_state --exclude-resource-type test`
+  - `HAS_STATE=true`, `NEEDS_FALLBACK=true`, `BUILD_SELECT` set → `build --select "<BUILD_SELECT> state:modified+" --defer ...`
+  - `HAS_STATE=true`, `NEEDS_FALLBACK=true`, no `BUILD_SELECT` → `build --select "state:modified+" --defer ...`
+  - `HAS_STATE=false` → `build --target ci --exclude-resource-type test` (full, no defer)
+  - `HAS_MODEL_CHANGES=false` → `dbt parse`, no build (existing)
+
+Shell tests validate **command construction**, not live dbt behavior; end-to-end correctness is
+confirmed by a follow-up weightcare-style no-op/real PR validation (out of this spec's automated
+scope).
+
+## Known limitations (accepted, documented)
+
+1. **Macro+model PRs: build ⊋ diff.** The build uses `"BUILD_SELECT state:modified+"` while the
+   diff uses `DIFF_SELECT` (git-only) — macro-affected models are built but not diffed. Narrow
+   edge; identical to weightcare; not a correctness bug (diffed models all exist). Closable later
+   by also appending `state:modified+` to the diff under `NEEDS_FALLBACK` (touches the diff
+   scripts — out of scope here).
+2. **Manifest dependence is narrowed, not eliminated.** Model-change PRs are manifest-independent
+   for build scoping; macro/config/yaml-only PRs still use `state:modified+` and can over-select if
+   the manifest is stale. A manifest-freshness guard (Approach C) is a possible later enhancement.
+3. **No manifest → full build** on every PR (the deviation above). Correct, but no scoping benefit
+   without a prod manifest — same as today, no regression.
+
+## Success criteria
+
+- `get_changed_models.sh` emits correct `BUILD_SELECT`/`NEEDS_FALLBACK` for all node/change types
+  (covered by the harness).
+- `ci_build.sh` constructs the correct `dbt build` command for each tier (covered by the harness).
+- All existing shell suites remain green after the `DIFF_SELECT`-widening change.
+- Build and diff select the same models for a model-change PR.

--- a/scripts/ci_build.sh
+++ b/scripts/ci_build.sh
@@ -6,9 +6,28 @@ set -euo pipefail
 #   2. Has state + model changes     → Slim CI (state:modified+ with --defer)
 #   3. Has state, state selection fails → full build (fallback)
 #   4. No state available            → full build
+#
+# Every `dbt build` invocation below excludes the `test` resource type:
+# models are built without running dbt tests, and `dbt test` runs as a
+# separate, non-blocking CI step afterward. This decouples the diff-gate
+# (steps.dbt_build.outcome) from test outcome, so a single red data test no
+# longer suppresses the data/schema diffs (see Risks & Trade-offs — this
+# intentionally removes dbt's upstream test-blocking within a build).
+# CI_SELECT / CI_DEFER are exported to $GITHUB_ENV so the downstream
+# `dbt test` step can reuse the same model selection/defer state.
 
 mkdir -p prod_state
 HAS_STATE="false"
+
+# Writes CI_SELECT / CI_DEFER to $GITHUB_ENV (when present) so the
+# non-blocking `dbt test` step added after this one can reuse the same
+# model selection/defer state that was used for the build.
+export_ci_select_defer() {
+  if [[ -n "${GITHUB_ENV:-}" ]]; then
+    echo "CI_SELECT=${CI_SELECT:-}" >> "$GITHUB_ENV"
+    echo "CI_DEFER=${CI_DEFER:-}" >> "$GITHUB_ENV"
+  fi
+}
 
 echo "=== Slim CI State Detection ==="
 echo "DBT_ARTIFACTS_BUCKET: ${DBT_ARTIFACTS_BUCKET:-<unset>}"
@@ -64,20 +83,27 @@ if [[ "${HAS_STATE}" == "true" ]]; then
   dbt ls --select "state:modified+" --state prod_state --resource-type model --output name --target ci || {
     echo "Error running dbt ls with state selection, falling back to full build"
     echo "Running full build due to state selection error"
-    dbt build --target ci
+    dbt build --target ci --exclude-resource-type test
+    build_status=$?
+    CI_SELECT=""; CI_DEFER=""
+    export_ci_select_defer
     echo ""
     echo "=== Build Complete (full, state selection failed) ==="
-    exit $?
+    exit $build_status
   }
 
   echo ""
-  echo "Starting Slim CI build with defer..."
-  dbt build --target ci --select "state:modified+" --defer --state prod_state
+  echo "Starting Slim CI build with defer (models only; tests run separately)..."
+  dbt build --target ci --select "state:modified+" --defer --state prod_state --exclude-resource-type test
+  CI_SELECT="state:modified+"; CI_DEFER="--defer --state prod_state"
 else
   echo "No production state available, running full build"
   echo "All models will be built from scratch"
-  dbt build --target ci
+  dbt build --target ci --exclude-resource-type test
+  CI_SELECT=""; CI_DEFER=""
 fi
 
 echo ""
 echo "=== Build Complete ==="
+
+export_ci_select_defer

--- a/scripts/ci_build.sh
+++ b/scripts/ci_build.sh
@@ -1,11 +1,17 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# CI build strategy (4-tier):
-#   1. No model changes detected    → dbt parse only (syntax check)
-#   2. Has state + model changes     → Slim CI (state:modified+ with --defer)
-#   3. Has state, state selection fails → full build (fallback)
-#   4. No state available            → full build
+# CI build strategy (git-diff-scoped):
+#   1. No model changes detected                     → dbt parse only (syntax check)
+#   2. No production manifest available               → full build (no --defer; cannot
+#                                                        safely scope without state)
+#   3. Manifest available, git-diff scope only         → build "$BUILD_SELECT" --defer
+#                                                        (unchanged ancestors defer to prod)
+#   4. Manifest available, macro/config change alongside
+#      model changes                                   → union "$BUILD_SELECT state:modified+"
+#                                                        --defer
+#   5. Manifest available, macro/config/YAML-only change
+#      (no scoped node)                                 → state:modified+ --defer
 #
 # Every `dbt build` invocation below excludes the `test` resource type:
 # models are built without running dbt tests, and `dbt test` runs as a
@@ -65,7 +71,7 @@ dbt deps
 echo ""
 echo "=== dbt Build Strategy ==="
 
-# Tier 1: No model changes → parse only
+# No dbt model changes → parse only (docs-only)
 if [[ "${HAS_MODEL_CHANGES:-true}" == "false" ]]; then
   echo "No dbt model changes detected in this PR. Running parse-only validation."
   dbt parse --target ci
@@ -74,33 +80,27 @@ if [[ "${HAS_MODEL_CHANGES:-true}" == "false" ]]; then
   exit 0
 fi
 
-# Tier 2-4: Model changes detected, build required
-if [[ "${HAS_STATE}" == "true" ]]; then
-  echo "Using Slim CI with state comparison and defer"
-  echo "Checking which models dbt detects as changed..."
-
-  echo "Models selected by state:modified+:"
-  dbt ls --select "state:modified+" --state prod_state --resource-type model --output name --target ci || {
-    echo "Error running dbt ls with state selection, falling back to full build"
-    echo "Running full build due to state selection error"
-    dbt build --target ci --exclude-resource-type test
-    build_status=$?
-    CI_SELECT=""; CI_DEFER=""
-    export_ci_select_defer
-    echo ""
-    echo "=== Build Complete (full, state selection failed) ==="
-    exit $build_status
-  }
-
-  echo ""
-  echo "Starting Slim CI build with defer (models only; tests run separately)..."
-  dbt build --target ci --select "state:modified+" --defer --state prod_state --exclude-resource-type test
-  CI_SELECT="state:modified+"; CI_DEFER="--defer --state prod_state"
-else
+if [[ "${HAS_STATE}" != "true" ]]; then
+  # No prod manifest → cannot defer safely → full build.
   echo "No production state available, running full build"
-  echo "All models will be built from scratch"
   dbt build --target ci --exclude-resource-type test
   CI_SELECT=""; CI_DEFER=""
+elif [[ "${NEEDS_FALLBACK:-false}" == "false" && -n "${BUILD_SELECT:-}" ]]; then
+  # Git-diff scoped build; unchanged ancestors defer to prod (build scope == diff scope).
+  echo "Strategy: git-diff scoped build — ${BUILD_SELECT}"
+  dbt build --target ci --select "${BUILD_SELECT}" --defer --state prod_state --exclude-resource-type test
+  CI_SELECT="${BUILD_SELECT}"; CI_DEFER="--defer --state prod_state"
+elif [[ "${NEEDS_FALLBACK:-false}" == "true" && -n "${BUILD_SELECT:-}" ]]; then
+  # Macro/config change alongside model changes → union git scope with state:modified+.
+  SEL="${BUILD_SELECT} state:modified+"
+  echo "Strategy: git-diff + state:modified+ combined — ${SEL}"
+  dbt build --target ci --select "${SEL}" --defer --state prod_state --exclude-resource-type test
+  CI_SELECT="${SEL}"; CI_DEFER="--defer --state prod_state"
+else
+  # Macro/config/yaml-only change (no scoped node) → state comparison.
+  echo "Strategy: state:modified+ fallback (macro/config/YAML-only change)"
+  dbt build --target ci --select "state:modified+" --defer --state prod_state --exclude-resource-type test
+  CI_SELECT="state:modified+"; CI_DEFER="--defer --state prod_state"
 fi
 
 echo ""

--- a/scripts/get_changed_models.sh
+++ b/scripts/get_changed_models.sh
@@ -38,15 +38,27 @@ done <<< "$CHANGED_FILES"
 
 CHANGED_MODELS=$(echo "$CHANGED_MODELS" | xargs)  # trim whitespace
 
+# Build the dbt selector: one 'name+' token per changed model (model + downstream).
+# Empty when no model files changed (e.g. docs-only), so the HAS_MODEL_CHANGES=false
+# skip still governs downstream.
+DIFF_SELECT=""
+for model_name in ${CHANGED_MODELS}; do
+  DIFF_SELECT="${DIFF_SELECT} ${model_name}+"
+done
+DIFF_SELECT=$(echo "$DIFF_SELECT" | xargs)  # trim whitespace
+
 echo ""
 echo "HAS_MODEL_CHANGES=${HAS_MODEL_CHANGES}"
 echo "CHANGED_MODELS=${CHANGED_MODELS:-<none>}"
+echo "DIFF_SELECT=${DIFF_SELECT:-<none>}"
 
 # Export to GitHub Actions env/output if available
 if [[ -n "${GITHUB_ENV:-}" ]]; then
   echo "HAS_MODEL_CHANGES=${HAS_MODEL_CHANGES}" >> "$GITHUB_ENV"
+  echo "DIFF_SELECT=${DIFF_SELECT}" >> "$GITHUB_ENV"
 fi
 if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
   echo "has_model_changes=${HAS_MODEL_CHANGES}" >> "$GITHUB_OUTPUT"
   echo "changed_models=${CHANGED_MODELS}" >> "$GITHUB_OUTPUT"
+  echo "diff_select=${DIFF_SELECT}" >> "$GITHUB_OUTPUT"
 fi

--- a/scripts/get_changed_models.sh
+++ b/scripts/get_changed_models.sh
@@ -1,10 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Detects which dbt model files changed in this PR vs origin/main.
-# Outputs:
-#   HAS_MODEL_CHANGES=true|false  (to $GITHUB_ENV if available, else stdout)
-#   CHANGED_MODELS=<space-separated model names> (to $GITHUB_OUTPUT or stdout)
+# Detects which dbt model/seed/snapshot files changed in this PR vs origin/main.
+# Outputs (to $GITHUB_ENV/$GITHUB_OUTPUT if available, else stdout):
+#   HAS_MODEL_CHANGES=true|false
+#   CHANGED_MODELS=<space-separated changed node names (models/seeds/snapshots)>
+#   DIFF_SELECT=<space-separated 'name+' selector tokens>
+#   BUILD_SELECT=<same value as DIFF_SELECT>
+#   NEEDS_FALLBACK=true|false  (a change couldn't be scoped by filename; caller
+#                               should fall back to state:modified+)
 #
 # Requires: git history (fetch-depth: 0 in checkout)
 
@@ -18,47 +22,67 @@ CHANGED_FILES=$(git diff --name-only "${BASE_REF}...HEAD" 2>/dev/null || git dif
 echo "Changed files:"
 echo "$CHANGED_FILES" | sed 's/^/  /'
 
-# Check if any dbt-relevant files changed
+# Categorize changed files; collect buildable node names (models, seeds, snapshots).
 HAS_MODEL_CHANGES=false
-CHANGED_MODELS=""
+CHANGED_NODES=""
+MACRO_OR_CONFIG=false
+YAML_CHANGED=false
 
 while IFS= read -r file; do
   [[ -z "$file" ]] && continue
-  if [[ "$file" =~ ^models/.*\.(sql|yml|yaml)$ ]]; then
-    HAS_MODEL_CHANGES=true
-    # Extract model name from path (e.g., models/staging/stg_foo.sql -> stg_foo)
-    if [[ "$file" == *.sql ]]; then
-      model_name=$(basename "$file" .sql)
-      CHANGED_MODELS="${CHANGED_MODELS} ${model_name}"
-    fi
-  elif [[ "$file" =~ ^(macros|seeds|snapshots)/ || "$file" == "dbt_project.yml" || "$file" == "packages.yml" ]]; then
-    HAS_MODEL_CHANGES=true
-  fi
+  case "$file" in
+    models/*.sql)
+      HAS_MODEL_CHANGES=true
+      CHANGED_NODES="${CHANGED_NODES} $(basename "$file" .sql)" ;;
+    seeds/*.csv)
+      HAS_MODEL_CHANGES=true
+      CHANGED_NODES="${CHANGED_NODES} $(basename "$file" .csv)" ;;
+    snapshots/*.sql)
+      HAS_MODEL_CHANGES=true
+      CHANGED_NODES="${CHANGED_NODES} $(basename "$file" .sql)" ;;
+    models/*.yml|models/*.yaml)
+      HAS_MODEL_CHANGES=true
+      YAML_CHANGED=true ;;
+    macros/*.sql|dbt_project.yml|packages.yml)
+      HAS_MODEL_CHANGES=true
+      MACRO_OR_CONFIG=true ;;
+  esac
 done <<< "$CHANGED_FILES"
 
-CHANGED_MODELS=$(echo "$CHANGED_MODELS" | xargs)  # trim whitespace
+CHANGED_NODES=$(echo "$CHANGED_NODES" | xargs)  # trim/normalize whitespace
 
-# Build the dbt selector: one 'name+' token per changed model (model + downstream).
-# Empty when no model files changed (e.g. docs-only), so the HAS_MODEL_CHANGES=false
-# skip still governs downstream.
-DIFF_SELECT=""
-for model_name in ${CHANGED_MODELS}; do
-  DIFF_SELECT="${DIFF_SELECT} ${model_name}+"
+# BUILD_SELECT == DIFF_SELECT: one 'name+' token per changed node (model + downstream;
+# no leading '+' so unchanged ancestors defer to prod). Empty for docs/macro/config-only.
+BUILD_SELECT=""
+for node in ${CHANGED_NODES}; do
+  BUILD_SELECT="${BUILD_SELECT} ${node}+"
 done
-DIFF_SELECT=$(echo "$DIFF_SELECT" | xargs)  # trim whitespace
+BUILD_SELECT=$(echo "$BUILD_SELECT" | xargs)
+DIFF_SELECT="$BUILD_SELECT"
+
+# Fallback needed when a change can't be scoped by filename: macros/config affect any model;
+# a yaml-only change (no node) can alter tests/configs on any model.
+NEEDS_FALLBACK=false
+if [[ "$MACRO_OR_CONFIG" == "true" ]]; then NEEDS_FALLBACK=true; fi
+if [[ "$YAML_CHANGED" == "true" && -z "$CHANGED_NODES" ]]; then NEEDS_FALLBACK=true; fi
 
 echo ""
 echo "HAS_MODEL_CHANGES=${HAS_MODEL_CHANGES}"
-echo "CHANGED_MODELS=${CHANGED_MODELS:-<none>}"
+echo "CHANGED_MODELS=${CHANGED_NODES:-<none>}"
 echo "DIFF_SELECT=${DIFF_SELECT:-<none>}"
+echo "BUILD_SELECT=${BUILD_SELECT:-<none>}"
+echo "NEEDS_FALLBACK=${NEEDS_FALLBACK}"
 
-# Export to GitHub Actions env/output if available
 if [[ -n "${GITHUB_ENV:-}" ]]; then
   echo "HAS_MODEL_CHANGES=${HAS_MODEL_CHANGES}" >> "$GITHUB_ENV"
   echo "DIFF_SELECT=${DIFF_SELECT}" >> "$GITHUB_ENV"
+  echo "BUILD_SELECT=${BUILD_SELECT}" >> "$GITHUB_ENV"
+  echo "NEEDS_FALLBACK=${NEEDS_FALLBACK}" >> "$GITHUB_ENV"
 fi
 if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
   echo "has_model_changes=${HAS_MODEL_CHANGES}" >> "$GITHUB_OUTPUT"
-  echo "changed_models=${CHANGED_MODELS}" >> "$GITHUB_OUTPUT"
+  echo "changed_models=${CHANGED_NODES}" >> "$GITHUB_OUTPUT"
   echo "diff_select=${DIFF_SELECT}" >> "$GITHUB_OUTPUT"
+  echo "build_select=${BUILD_SELECT}" >> "$GITHUB_OUTPUT"
+  echo "needs_fallback=${NEEDS_FALLBACK}" >> "$GITHUB_OUTPUT"
 fi

--- a/scripts/pr_data_diff.sh
+++ b/scripts/pr_data_diff.sh
@@ -13,6 +13,12 @@ DEV_PROJECT=${DBT_GCP_PROJECT_CI:?set DBT_GCP_PROJECT_CI}
 DEV_DATASET=${DBT_BQ_DATASET:?set DBT_BQ_DATASET}
 PROD_PROJECT=${DBT_GCP_PROJECT_PROD:-}
 
+# Docs/config-only PRs change no models — skip the diff entirely (no gsutil, no dbt).
+if [[ "${HAS_MODEL_CHANGES:-true}" == "false" ]]; then
+  echo "No dbt model changes detected in this PR. No models to diff."
+  exit 0
+fi
+
 # Pull prod manifest if not already present (optional, CI workflow usually does this earlier)
 echo "=== Data Diff State Detection ==="
 echo "Checking for production manifest for model selection..."
@@ -33,20 +39,18 @@ fi
 
 echo ""
 echo "=== Model Selection ==="
-if [[ -f prod_state/manifest.json ]]; then
+if [[ -n "${DIFF_SELECT:-}" ]]; then
+  echo "Using git-diff scope: ${DIFF_SELECT}"
+  # DIFF_SELECT is intentionally unquoted so multiple 'name+' tokens expand as separate args.
+  mapfile -t MODELS < <(dbt ls --select ${DIFF_SELECT} --resource-type model --output name --quiet 2>/dev/null || true)
+elif [[ -f prod_state/manifest.json ]]; then
   echo "Using state comparison to find changed models..."
   mapfile -t MODELS < <(dbt ls --select "state:modified+" --state prod_state --resource-type model --output name --quiet 2>/dev/null || true)
-  echo "Models detected as state:modified+:"
-  if (( ${#MODELS[@]} == 0 )); then
-    echo "  (none - no models changed)"
-  else
-    printf "  - %s\n" "${MODELS[@]}"
-  fi
 else
-  echo "No production manifest available, selecting all models..."
+  echo "No git scope and no production manifest; selecting all models..."
   mapfile -t MODELS < <(dbt ls --resource-type model --output name --quiet 2>/dev/null || true)
-  echo "All models selected (${#MODELS[@]} total)"
 fi
+echo "Selected ${#MODELS[@]} model(s)."
 
 if (( ${#MODELS[@]} == 0 )); then
   echo "No models to diff."

--- a/scripts/pr_schema_diff.sh
+++ b/scripts/pr_schema_diff.sh
@@ -225,10 +225,23 @@ echo >> "$summary_md"
 echo "| Model | Status | Moved | Type Change | +Cols | -Cols | Changed | Part/Cluster Changes |" >> "$summary_md"
 echo "|---|---|---|---|---:|---:|---:|---|" >> "$summary_md"
 
+# Movement is a LOGICAL question: did this PR change the model's database,
+# schema or alias relative to production? It must therefore compare the PR
+# manifest node against the PROD manifest node.
+#
+# It must NOT compare the physical locations that were introspected: DEV_P/DEV_D
+# are deliberately forced to the CI project and the ephemeral CI dataset, so a
+# physical comparison differs by construction and reported every model as MOVED
+# (measured: 37/37 on a replay of PR #72).
+#
+# $3 is "true" only when the prod FQN came from a real prod-manifest node. When
+# no prod node was found the prod FQN is synthesised from the PR's own
+# identifier, so comparing against it would manufacture a confident UNCHANGED
+# that was never actually checked. That case is genuinely UNKNOWN.
 movement_status() {
-  local dev_fqn=$1 prod_fqn=$2
-  if [[ -z "$prod_fqn" ]]; then echo "UNKNOWN"; return; fi
-  if [[ "$dev_fqn" == "$prod_fqn" ]]; then echo "UNCHANGED"; else echo "MOVED"; fi
+  local pr_fqn=$1 prod_fqn=$2 prod_from_manifest=${3:-false}
+  if [[ "$prod_from_manifest" != "true" || -z "$prod_fqn" ]]; then echo "UNKNOWN"; return; fi
+  if [[ "$pr_fqn" == "$prod_fqn" ]]; then echo "UNCHANGED"; else echo "MOVED"; fi
 }
 
 for m in "${MODELS[@]}"; do
@@ -251,8 +264,12 @@ for m in "${MODELS[@]}"; do
   # Dev side uses CI env regardless of manifest database to ensure correctness
   DEV_P="$DEV_PROJECT"; DEV_D="$DEV_DATASET"; DEV_T="$pr_ident"
 
-  # Prod node (from prod manifest preferred)
+  # Prod node (from prod manifest preferred).
+  # prod_from_manifest records whether the prod FQN below is a real observation
+  # of production or a fallback synthesised from configuration. Movement is only
+  # answerable in the former case.
   prod_fqn_json=""
+  prod_from_manifest=false
   if [[ -f "$PROD_MANIFEST" && -n "$pr_uid" && "$pr_uid" != "null" ]]; then
     prod_node=$(get_node_by_uid "$PROD_MANIFEST" "$pr_uid")
     if [[ -z "$prod_node" || "$prod_node" == "null" ]]; then
@@ -261,6 +278,7 @@ for m in "${MODELS[@]}"; do
     fi
     if [[ -n "$prod_node" && "$prod_node" != "null" ]]; then
       prod_fqn_json=$(echo "$prod_node" | node_to_fqn)
+      prod_from_manifest=true
     fi
   fi
 
@@ -272,14 +290,27 @@ for m in "${MODELS[@]}"; do
   PROD_D=$(echo "$prod_fqn_json" | jq -r .dataset)
   PROD_T=$(echo "$prod_fqn_json" | jq -r .identifier)
 
+  # Physical relations that are actually introspected below. The dev side is
+  # pinned to the ephemeral CI dataset on purpose; these two lines are for
+  # debugging the queries, NOT for movement detection.
   dev_fqn_str="$DEV_P.$DEV_D.$DEV_T"
   prod_fqn_str="$PROD_P.$PROD_D.$PROD_T"
+  echo "Physical relations queried:" | tee -a "$out"
   echo "Dev:  $dev_fqn_str" | tee -a "$out"
   echo "Prod: $prod_fqn_str" | tee -a "$out"
 
-  move=$(movement_status "$dev_fqn_str" "$prod_fqn_str")
+  # Logical (manifest) locations. Movement compares these.
+  pr_logical_fqn="$pr_proj.$pr_ds.$pr_ident"
+  prod_logical_fqn=""
+  if [[ "$prod_from_manifest" == "true" ]]; then
+    prod_logical_fqn="$PROD_P.$PROD_D.$PROD_T"
+  fi
+  echo "Logical PR:   $pr_logical_fqn" | tee -a "$out"
+  echo "Logical prod: ${prod_logical_fqn:-<not in prod manifest>}" | tee -a "$out"
+
+  move=$(movement_status "$pr_logical_fqn" "$prod_logical_fqn" "$prod_from_manifest")
   if [[ "$move" == "MOVED" ]]; then
-    echo "Movement: $prod_fqn_str -> $dev_fqn_str" | tee -a "$out"
+    echo "Movement: $prod_logical_fqn -> $pr_logical_fqn" | tee -a "$out"
   else
     echo "Movement: $move" | tee -a "$out"
   fi
@@ -365,9 +396,10 @@ for m in "${MODELS[@]}"; do
   echo "SUMMARY|model=$m|status=$status|moved=$move|type_change=${type_change:-none}|added=$added|removed=$removed|changed=$changed|opt_changes=$opt_changes_cnt" | tee -a "$out"
 
   # Append to markdown table
+  # Show the LOGICAL move (prod manifest → PR manifest), never the CI dataset.
   moved_cell="$move"
   if [[ "$move" == "MOVED" ]]; then
-    moved_cell="$prod_fqn_str → $dev_fqn_str"
+    moved_cell="$prod_logical_fqn → $pr_logical_fqn"
   fi
   partcell=$( [[ "$opt_changes_cnt" -gt 0 ]] && echo "yes" || echo "no" )
   echo "| $m | $status | $moved_cell | ${type_change:-} | $added | $removed | $changed | $partcell |" >> "$summary_md"

--- a/scripts/pr_schema_diff.sh
+++ b/scripts/pr_schema_diff.sh
@@ -536,7 +536,7 @@ orphans_md="$ARTIFACT_DIR/orphans.md"
       (.sources | to_entries[] | .value | source_key(.))
     ] | flatten | unique | .[]' "$manifest_for_orphans" 2>/dev/null || true)
 
-  declare -A covered
+  declare -A covered=()
   while IFS= read -r line; do
     [[ -n "$line" ]] && covered["$line"]=1
   done <<< "$coverage"

--- a/scripts/pr_schema_diff.sh
+++ b/scripts/pr_schema_diff.sh
@@ -73,13 +73,15 @@ if (( ${#MODELS[@]} == 0 )); then
 fi
 
 # Helper: get model node JSON from manifest by name
+# The manifest path must be passed to jq. Without it jq reads stdin, which is
+# empty under CI, so every lookup returned nothing and every model was skipped.
 get_node_by_name() {
-  local manifest=$1 name=$2
+  local manifest=$1
   jq -r --arg n "$2" '
-    .nodes 
+    .nodes
     | to_entries[]
     | select(.value.resource_type=="model" and .value.name==$n)
-    | .value'
+    | .value' "$manifest"
 }
 
 # Helper: get node by unique_id from manifest
@@ -161,7 +163,7 @@ compute_meta_diff() {
       require_partition_filter: ($o.require_partition_filter // null),
       clustering_fields: ($o.clustering_fields // null)
     };
-    (norm(devo)) as $d | (norm(prodo)) as $p |
+    (norm($devo)) as $d | (norm($prodo)) as $p |
     {
       table_type_change: (if ($devt|length)==0 or ($prodt|length)==0 then null else (if $devt==$prodt then null else {from:$prodt, to:$devt} end) end),
       option_changes: ( [

--- a/scripts/pr_schema_diff.sh
+++ b/scripts/pr_schema_diff.sh
@@ -130,6 +130,22 @@ bq_table_options() {
   bq_json "$project" "$sql"
 }
 
+# Returns 0 if the argument parses as a JSON array.
+is_json_array() {
+  [[ -n "${1:-}" ]] && printf '%s' "$1" | jq -e 'type=="array"' >/dev/null 2>&1
+}
+
+# Echoes the argument if it is a JSON array, otherwise an empty array.
+# Apply ONLY where a value is handed to jq. Status classification reads the
+# raw bq output, because "Access Denied" is a signal that normalizing destroys.
+as_json_array() {
+  if is_json_array "${1:-}"; then
+    printf '%s' "$1"
+  else
+    printf '[]'
+  fi
+}
+
 normalize_options() {
   jq -r '[.[] | {key: .option_name, val: .option_value}] | map({(.key): .val}) | add // {}'
 }
@@ -253,26 +269,41 @@ for m in "${MODELS[@]}"; do
   dev_opts_json=$(bq_table_options "$DEV_P" "$DEV_D" "$DEV_T" 2>/dev/null || true)
   prod_opts_json=$(bq_table_options "$PROD_P" "$PROD_D" "$PROD_T" 2>/dev/null || true)
 
+  # --- Classify from RAW output. Do not normalize before this block: ---
+  # as_json_array would rewrite "Access Denied" to "[]", which is non-empty and
+  # no longer matches the substring test, silently downgrading a permissions
+  # failure to a clean OK diff.
   status="OK"
   if [[ -z "$prod_cols_json" || "$prod_cols_json" == *"Access Denied"* ]]; then
     status="AUTH_ERROR"
+  elif ! is_json_array "$prod_cols_json"; then
+    status="NON_JSON"
   fi
 
-  # Detect new model (no prod cols and no tables row)
-  prod_type=$(echo "${prod_type_json:-[]}" | jq -r '.[0].table_type // empty')
-  if [[ -z "$prod_type" && "$status" != "AUTH_ERROR" ]]; then
+  # --- Normalize at the jq boundary. ---
+  dev_cols=$(as_json_array "${dev_cols_json:-}")
+  prod_cols=$(as_json_array "${prod_cols_json:-}")
+  dev_type_arr=$(as_json_array "${dev_type_json:-}")
+  prod_type_arr=$(as_json_array "${prod_type_json:-}")
+  dev_opts_arr=$(as_json_array "${dev_opts_json:-}")
+  prod_opts_arr=$(as_json_array "${prod_opts_json:-}")
+
+  # Detect new model (no prod table row). Only reclassify a clean OK status so
+  # AUTH_ERROR and NON_JSON are not overwritten.
+  prod_type=$(printf '%s' "$prod_type_arr" | jq -r '.[0].table_type // empty')
+  if [[ -z "$prod_type" && "$status" == "OK" ]]; then
     status="NEW_MODEL"
   fi
-  dev_type=$(echo "${dev_type_json:-[]}" | jq -r '.[0].table_type // empty')
+  dev_type=$(printf '%s' "$dev_type_arr" | jq -r '.[0].table_type // empty')
 
   # Normalize options
-  dev_opts=$(echo "${dev_opts_json:-[]}" | jq -r ' . | (if type=="array" then . else [] end) ' | normalize_options)
-  prod_opts=$(echo "${prod_opts_json:-[]}" | jq -r ' . | (if type=="array" then . else [] end) ' | normalize_options)
+  dev_opts=$(printf '%s' "$dev_opts_arr" | normalize_options)
+  prod_opts=$(printf '%s' "$prod_opts_arr" | normalize_options)
 
   # Column diff (skip if auth error and not new model)
   added=0; removed=0; changed=0
   if [[ "$status" == "OK" || "$status" == "NEW_MODEL" ]]; then
-    col_diff=$(compute_column_diff "${dev_cols_json:-[]}" "${prod_cols_json:-[]}")
+    col_diff=$(compute_column_diff "$dev_cols" "$prod_cols")
     added=$(echo "$col_diff" | jq -r '.added | length')
     removed=$(echo "$col_diff" | jq -r '.removed | length')
     changed=$(echo "$col_diff" | jq -r '.changed | length')

--- a/scripts/pr_schema_diff.sh
+++ b/scripts/pr_schema_diff.sh
@@ -22,6 +22,12 @@ DEV_DATASET=${DBT_BQ_DATASET:?set DBT_BQ_DATASET}
 PROD_PROJECT=${DBT_GCP_PROJECT_PROD:-$DEV_PROJECT}
 DEFAULT_PROD_DATASET=${DBT_BQ_DATASET_PROD:-analytics}
 
+# Docs/config-only PRs change no models — skip the diff entirely (no jq/bq/dbt work).
+if [[ "${HAS_MODEL_CHANGES:-true}" == "false" ]]; then
+  echo "No dbt model changes detected in this PR. No models for schema diff."
+  exit 0
+fi
+
 command -v jq >/dev/null || {
   echo "[warn] jq not found; schema diff requires jq. Skipping." >&2
   exit 0
@@ -55,7 +61,11 @@ fi
 
 echo ""
 echo "=== Model Selection ==="
-if [[ -f "$PROD_MANIFEST" ]]; then
+if [[ -n "${DIFF_SELECT:-}" ]]; then
+  echo "Using git-diff scope: ${DIFF_SELECT}"
+  # DIFF_SELECT is intentionally unquoted so multiple 'name+' tokens expand as separate args.
+  mapfile -t MODELS < <(dbt ls --select ${DIFF_SELECT} --resource-type model --output name --quiet 2>/dev/null || true)
+elif [[ -f "$PROD_MANIFEST" ]]; then
   mapfile -t MODELS < <(dbt ls --select "state:modified+" --state prod_state --resource-type model --output name --quiet 2>/dev/null || true)
   if (( ${#MODELS[@]} == 0 )); then
     echo "  (none - no models changed)"

--- a/scripts/pr_schema_diff.sh
+++ b/scripts/pr_schema_diff.sh
@@ -306,58 +306,71 @@ for m in "${MODELS[@]}"; do
   echo "| $m | $status | $moved_cell | ${type_change:-} | $added | $removed | $changed | $partcell |" >> "$summary_md"
 done
 
-# Orphans report — only if we can read prod
+# Orphans report — best-effort, never fails CI.
+# Isolated in a subshell with relaxed error handling: this is a side report,
+# and a failure here must never abort the schema diff for changed models.
 orphans_md="$ARTIFACT_DIR/orphans.md"
-echo "# Orphaned Production Relations" > "$orphans_md"
-echo >> "$orphans_md"
-echo "_Generated: $(date -u +"%Y-%m-%d %H:%M:%S UTC")_" >> "$orphans_md"
-echo >> "$orphans_md"
+(
+  set +euo pipefail
 
-# Build coverage set from manifest (prefer prod manifest, else PR manifest)
-manifest_for_orphans="$PR_MANIFEST"
-if [[ -f "$PROD_MANIFEST" ]]; then
-  manifest_for_orphans="$PROD_MANIFEST"
-fi
+  echo "# Orphaned Production Relations" > "$orphans_md"
+  echo >> "$orphans_md"
+  echo "_Generated: $(date -u +"%Y-%m-%d %H:%M:%S UTC")_" >> "$orphans_md"
+  echo >> "$orphans_md"
 
-# Helper: coverage keys as dataset.table strings
-coverage=$(jq -r '
-  def model_key($p): (.schema + "." + ((.alias // .name) // ""));
-  def source_key($p): (.schema + "." + ((.identifier // .name) // ""));
-  [
-    (.nodes | to_entries[] | .value | select(.resource_type=="model") | model_key(.)) ,
-    (.sources | to_entries[] | .value | source_key(.))
-  ] | flatten | unique | .[]' "$manifest_for_orphans" 2>/dev/null || true)
-
-declare -A covered
-while IFS= read -r line; do
-  [[ -n "$line" ]] && covered["$line"]=1
-done <<< "$coverage"
-
-declare -a orphans
-for ds in "${PROD_DATASETS_ARR[@]}"; do
-  tables_json=$(bq_table_type "$PROD_PROJECT" "$ds" "__all__" 2>/dev/null || true)
-  # If we queried __all__, it will be empty; instead list via INFORMATION_SCHEMA.TABLES
-  list_json=$(bq_json "$PROD_PROJECT" "SELECT table_name, table_type FROM \`$PROD_PROJECT.$ds\`.INFORMATION_SCHEMA.TABLES") || true
-  if [[ -z "$list_json" ]]; then
-    echo "[warn] Could not list tables in $PROD_PROJECT.$ds (no access?)" >> "$orphans_md"
-    continue
+  # Build coverage set from manifest (prefer prod manifest, else PR manifest)
+  manifest_for_orphans="$PR_MANIFEST"
+  if [[ -f "$PROD_MANIFEST" ]]; then
+    manifest_for_orphans="$PROD_MANIFEST"
   fi
-  while IFS= read -r name; do
-    key="$ds.$name"
-    if [[ -z "${covered[$key]:-}" ]]; then
-      orphans+=("$PROD_PROJECT.$ds.$name")
-    fi
-  done < <(echo "$list_json" | jq -r '.[].table_name')
-done
 
-echo "Found ${#orphans[@]} orphan(s)." >> "$orphans_md"
-if (( ${#orphans[@]} > 0 )); then
-  echo "" >> "$orphans_md"
-  echo "## Examples" >> "$orphans_md"
-  for o in "${orphans[@]:0:50}"; do
-    echo "- $o" >> "$orphans_md"
+  coverage=$(jq -r '
+    def model_key($p): (.schema + "." + ((.alias // .name) // ""));
+    def source_key($p): (.schema + "." + ((.identifier // .name) // ""));
+    [
+      (.nodes | to_entries[] | .value | select(.resource_type=="model") | model_key(.)) ,
+      (.sources | to_entries[] | .value | source_key(.))
+    ] | flatten | unique | .[]' "$manifest_for_orphans" 2>/dev/null || true)
+
+  declare -A covered
+  while IFS= read -r line; do
+    [[ -n "$line" ]] && covered["$line"]=1
+  done <<< "$coverage"
+
+  # Explicitly initialized: `declare -a orphans` alone leaves the array unset,
+  # and `${#orphans[@]}` on an unset array is an unbound-variable error under
+  # `set -u` even on bash 5 (the 4.4 relaxation covers ${a[@]}, not ${#a[@]}).
+  declare -a orphans=()
+  for ds in "${PROD_DATASETS_ARR[@]}"; do
+    list_json=$(bq_json "$PROD_PROJECT" "SELECT table_name, table_type FROM \`$PROD_PROJECT.$ds\`.INFORMATION_SCHEMA.TABLES") || true
+    if [[ -z "$list_json" ]]; then
+      echo "[warn] Could not list tables in $PROD_PROJECT.$ds (no access?)" >> "$orphans_md"
+      continue
+    fi
+    # Guard the parse: bq can emit banner text that is not valid JSON.
+    table_names=$(printf '%s' "$list_json" | jq -r '.[].table_name' 2>/dev/null) || true
+    if [[ -z "$table_names" ]]; then
+      echo "[warn] Could not parse table list for $PROD_PROJECT.$ds" >> "$orphans_md"
+      continue
+    fi
+    while IFS= read -r name; do
+      [[ -z "$name" ]] && continue
+      key="$ds.$name"
+      if [[ -z "${covered[$key]:-}" ]]; then
+        orphans+=("$PROD_PROJECT.$ds.$name")
+      fi
+    done <<< "$table_names"
   done
-fi
+
+  echo "Found ${#orphans[@]} orphan(s)." >> "$orphans_md"
+  if (( ${#orphans[@]} > 0 )); then
+    echo "" >> "$orphans_md"
+    echo "## Examples" >> "$orphans_md"
+    for o in "${orphans[@]:0:50}"; do
+      echo "- $o" >> "$orphans_md"
+    done
+  fi
+) || echo "[warn] Orphan detection encountered errors; see $orphans_md" >&2
 
 echo "Schema diff reports written to $ARTIFACT_DIR/"
 exit 0

--- a/scripts/pr_schema_diff.sh
+++ b/scripts/pr_schema_diff.sh
@@ -75,13 +75,20 @@ fi
 # Helper: get model node JSON from manifest by name
 # The manifest path must be passed to jq. Without it jq reads stdin, which is
 # empty under CI, so every lookup returned nothing and every model was skipped.
+# Model names are only unique within a package, so a name shared with an
+# installed package used to emit two concatenated objects and corrupt the SQL.
+# Return exactly one node: this project's own model wins, otherwise the first
+# match in manifest order.
 get_node_by_name() {
   local manifest=$1
   jq -r --arg n "$2" '
-    .nodes
-    | to_entries[]
-    | select(.value.resource_type=="model" and .value.name==$n)
-    | .value' "$manifest"
+    (.metadata.project_name // "") as $proj
+    | [ .nodes
+        | to_entries[]
+        | select(.value.resource_type=="model" and .value.name==$n)
+        | .value ]
+    | (map(select(.package_name == $proj)) + .)
+    | (.[0] // empty)' "$manifest"
 }
 
 # Helper: get node by unique_id from manifest
@@ -135,6 +142,19 @@ is_json_array() {
   [[ -n "${1:-}" ]] && printf '%s' "$1" | jq -e 'type=="array"' >/dev/null 2>&1
 }
 
+# Classifies ONE raw bq result: OK | AUTH_ERROR | NON_JSON.
+# Must be called on the raw value, before as_json_array touches it.
+classify_raw() {
+  local raw=${1:-}
+  if [[ -z "$raw" || "$raw" == *"Access Denied"* ]]; then
+    echo "AUTH_ERROR"
+  elif ! is_json_array "$raw"; then
+    echo "NON_JSON"
+  else
+    echo "OK"
+  fi
+}
+
 # Echoes the argument if it is a JSON array, otherwise an empty array.
 # Apply ONLY where a value is handed to jq. Status classification reads the
 # raw bq output, because "Access Denied" is a signal that normalizing destroys.
@@ -152,7 +172,9 @@ normalize_options() {
 
 compute_column_diff() {
   local dev_json=$1 prod_json=$2
-  jq -r --argjson dev "$dev_json" --argjson prod "$prod_json" '
+  # `-n` is required: nothing is piped in, so without it jq has zero inputs,
+  # runs the filter zero times, and exits 0 having printed nothing.
+  jq -n -r --argjson dev "$dev_json" --argjson prod "$prod_json" '
     def mapcols($arr): reduce $arr[] as $c ({}; .[$c.column_name] = {type: $c.data_type, nullable: $c.is_nullable});
     def keys_of($m): ($m|keys|sort);
     def inter($a;$b): ($a + $b | group_by(.) | map(select(length==2) | .[0]));
@@ -172,7 +194,8 @@ compute_column_diff() {
 
 compute_meta_diff() {
   local dev_type=$1 prod_type=$2 dev_opts_json=$3 prod_opts_json=$4
-  jq -r --arg devt "$dev_type" --arg prodt "$prod_type" --argjson devo "$dev_opts_json" --argjson prodo "$prod_opts_json" '
+  # `-n` is required here for the same reason as in compute_column_diff.
+  jq -n -r --arg devt "$dev_type" --arg prodt "$prod_type" --argjson devo "$dev_opts_json" --argjson prodo "$prod_opts_json" '
     def norm($o): {
       partitioning_type: ($o.partitioning_type // null),
       partitioning_field: ($o.partitioning_field // null),
@@ -273,12 +296,23 @@ for m in "${MODELS[@]}"; do
   # as_json_array would rewrite "Access Denied" to "[]", which is non-empty and
   # no longer matches the substring test, silently downgrading a permissions
   # failure to a clean OK diff.
+  #
+  # Every value that feeds the diff is classified, on both sides. Classifying
+  # only prod columns left two silent downgrades: a denial on the prod TABLES
+  # query reported a permissions failure as NEW_MODEL, and a denial on the dev
+  # COLUMNS query reported every prod column as removed under status=OK.
+  # Table options are deliberately excluded: a zero-row TABLE_OPTIONS result is
+  # normal for an unpartitioned table and is not distinguishable from a failure.
   status="OK"
-  if [[ -z "$prod_cols_json" || "$prod_cols_json" == *"Access Denied"* ]]; then
-    status="AUTH_ERROR"
-  elif ! is_json_array "$prod_cols_json"; then
-    status="NON_JSON"
-  fi
+  for raw_result in "$prod_cols_json" "$dev_cols_json" "$prod_type_json" "$dev_type_json"; do
+    raw_class=$(classify_raw "$raw_result")
+    if [[ "$raw_class" == "AUTH_ERROR" ]]; then
+      status="AUTH_ERROR"
+      break
+    elif [[ "$raw_class" == "NON_JSON" && "$status" == "OK" ]]; then
+      status="NON_JSON"
+    fi
+  done
 
   # --- Normalize at the jq boundary. ---
   dev_cols=$(as_json_array "${dev_cols_json:-}")

--- a/scripts/pr_schema_diff.sh
+++ b/scripts/pr_schema_diff.sh
@@ -119,27 +119,124 @@ bq_json() {
   echo "$out"
 }
 
+# Returns 0 if the argument parses as a JSON array.
+is_json_array() {
+  [[ -n "${1:-}" ]] && printf '%s' "$1" | jq -e 'type=="array"' >/dev/null 2>&1
+}
+
+# --- Dataset-wide INFORMATION_SCHEMA cache -------------------------------
+#
+# The per-model loop asks six questions per model. Asked per model that is
+# 6 * N queries (241 at the real CI selection size of 40 models), each one a
+# fresh `bq` process plus an API round trip, against a step capped at
+# timeout-minutes: 10. Asked per (project, dataset) it is 3 queries per dataset
+# — 6 for a typical dev+prod run — regardless of model count.
+#
+# So: query the whole dataset once, cache the RAW output, and filter per model
+# locally with jq. The three helpers below keep their original signatures and
+# still echo a JSON array for one table, so the call sites and the status
+# classification block are untouched.
+#
+# Declared initialized. A bare `declare -A` leaves the array unset, and reading
+# an unset array under `set -u` is the class of defect this file was fixed for.
+# Loaded-ness is tracked separately from content so a genuinely empty result is
+# distinguishable from "not fetched yet" — a failed fetch caches as an empty
+# string and must NOT be retried per model, or the query volume comes back.
+declare -A DS_LOADED=()
+declare -A DS_COLS=()
+declare -A DS_TBL=()
+declare -A DS_OPT=()
+
+ensure_columns_cached() {
+  local project=$1 dataset=$2 key="$1.$2"
+  if [[ -z "${DS_LOADED[cols:$key]:-}" ]]; then
+    DS_LOADED[cols:$key]=1
+    DS_COLS[$key]=$(bq_json "$project" "SELECT table_name, column_name, ordinal_position, data_type, is_nullable FROM \`$project.$dataset\`.INFORMATION_SCHEMA.COLUMNS ORDER BY table_name, ordinal_position" || true)
+  fi
+  return 0
+}
+
+ensure_tables_cached() {
+  local project=$1 dataset=$2 key="$1.$2"
+  if [[ -z "${DS_LOADED[tbl:$key]:-}" ]]; then
+    DS_LOADED[tbl:$key]=1
+    DS_TBL[$key]=$(bq_json "$project" "SELECT table_name, table_type FROM \`$project.$dataset\`.INFORMATION_SCHEMA.TABLES" || true)
+  fi
+  return 0
+}
+
+ensure_options_cached() {
+  local project=$1 dataset=$2 key="$1.$2"
+  if [[ -z "${DS_LOADED[opt:$key]:-}" ]]; then
+    DS_LOADED[opt:$key]=1
+    DS_OPT[$key]=$(bq_json "$project" "SELECT table_name, option_name, option_value FROM \`$project.$dataset\`.INFORMATION_SCHEMA.TABLE_OPTIONS WHERE option_name IN ('partitioning_type','partitioning_field','require_partition_filter','clustering_fields')" || true)
+  fi
+  return 0
+}
+
+# Warms all three blobs for one (project, dataset) pair.
+#
+# This MUST be called as a plain statement from the shell that owns the cache.
+# The helpers below are invoked as `x=$(bq_columns ...)`, i.e. inside command
+# substitutions, which are subshells: anything they cache dies with them. A
+# lazy load driven only from inside the helpers would therefore never survive a
+# single model and the query count would be worse than before batching.
+ensure_dataset_cached() {
+  local project=$1 dataset=$2
+  ensure_columns_cached "$project" "$dataset"
+  ensure_tables_cached "$project" "$dataset"
+  ensure_options_cached "$project" "$dataset"
+  return 0
+}
+
+# Filters a cached dataset-wide blob down to one table.
+#
+# ERROR PASSTHROUGH — the load-bearing part. Status classification reads the
+# raw bq output and tests it as a string ("Access Denied", empty, banner text).
+# Before batching each model triggered its own query and so saw the failure
+# directly. Now the failure happens once, at load time, for the whole dataset.
+# A blob that is not a JSON array is therefore handed back VERBATIM to every
+# model in that dataset, so each one classifies exactly as it would have. Try
+# to jq-filter it instead and jq fails, the helper emits an empty array, and a
+# whole dataset's permissions failure turns into a clean OK diff on every row.
+ds_filter() {
+  local raw=${1:-} ident=$2 projection=$3
+  if ! is_json_array "$raw"; then
+    printf '%s' "$raw"
+    return 0
+  fi
+  printf '%s' "$raw" | jq -c --arg t "$ident" "[ .[] | select(.table_name == \$t) | $projection ]"
+}
+
 bq_columns() {
   local project=$1 dataset=$2 ident=$3
-  local sql="SELECT column_name, ordinal_position, data_type, is_nullable FROM \`$project.$dataset\`.INFORMATION_SCHEMA.COLUMNS WHERE table_name = '$ident' ORDER BY ordinal_position"
-  bq_json "$project" "$sql"
+  ensure_columns_cached "$project" "$dataset"
+  ds_filter "${DS_COLS[$project.$dataset]:-}" "$ident" \
+    '{column_name, ordinal_position, data_type, is_nullable}'
 }
 
 bq_table_type() {
   local project=$1 dataset=$2 ident=$3
-  local sql="SELECT table_type FROM \`$project.$dataset\`.INFORMATION_SCHEMA.TABLES WHERE table_name = '$ident'"
-  bq_json "$project" "$sql"
+  ensure_tables_cached "$project" "$dataset"
+  ds_filter "${DS_TBL[$project.$dataset]:-}" "$ident" '{table_type}'
 }
 
 bq_table_options() {
   local project=$1 dataset=$2 ident=$3
-  local sql="SELECT option_name, option_value FROM \`$project.$dataset\`.INFORMATION_SCHEMA.TABLE_OPTIONS WHERE table_name = '$ident' AND option_name IN ('partitioning_type','partitioning_field','require_partition_filter','clustering_fields')"
-  bq_json "$project" "$sql"
+  ensure_options_cached "$project" "$dataset"
+  ds_filter "${DS_OPT[$project.$dataset]:-}" "$ident" '{option_name, option_value}'
 }
 
-# Returns 0 if the argument parses as a JSON array.
-is_json_array() {
-  [[ -n "${1:-}" ]] && printf '%s' "$1" | jq -e 'type=="array"' >/dev/null 2>&1
+# Raw dataset-wide TABLES listing, for the orphan report.
+#
+# The orphan block wants exactly what the batched TABLES query already fetched:
+# `SELECT table_name, table_type` over the whole dataset. The two are the same
+# query, so they deliberately SHARE one cache entry rather than being issued
+# twice. Returns the raw blob; the caller does its own guarded parse.
+bq_tables_raw() {
+  local project=$1 dataset=$2
+  ensure_tables_cached "$project" "$dataset"
+  printf '%s' "${DS_TBL[$project.$dataset]:-}"
 }
 
 # Classifies ONE raw bq result: OK | AUTH_ERROR | NON_JSON.
@@ -315,6 +412,14 @@ for m in "${MODELS[@]}"; do
     echo "Movement: $move" | tee -a "$out"
   fi
 
+  # Warm the dataset-wide cache in THIS shell, before the six calls below. Each
+  # of those runs inside a command substitution — a subshell — so a cache it
+  # populates is discarded the moment it returns. Warming here is what makes the
+  # cache survive from one model to the next; without it every model would
+  # re-query and batching would buy nothing.
+  ensure_dataset_cached "$DEV_P" "$DEV_D"
+  ensure_dataset_cached "$PROD_P" "$PROD_D"
+
   # Introspect
   dev_cols_json=$(bq_columns "$DEV_P" "$DEV_D" "$DEV_T" 2>/dev/null || true)
   prod_cols_json=$(bq_columns "$PROD_P" "$PROD_D" "$PROD_T" 2>/dev/null || true)
@@ -441,7 +546,10 @@ orphans_md="$ARTIFACT_DIR/orphans.md"
   # `set -u` even on bash 5 (the 4.4 relaxation covers ${a[@]}, not ${#a[@]}).
   declare -a orphans=()
   for ds in "${PROD_DATASETS_ARR[@]}"; do
-    list_json=$(bq_json "$PROD_PROJECT" "SELECT table_name, table_type FROM \`$PROD_PROJECT.$ds\`.INFORMATION_SCHEMA.TABLES") || true
+    # Same query as the batched TABLES fetch, so it reuses that cache entry
+    # instead of issuing a duplicate. For a prod dataset the model loop already
+    # visited this costs nothing.
+    list_json=$(bq_tables_raw "$PROD_PROJECT" "$ds") || true
     if [[ -z "$list_json" ]]; then
       echo "[warn] Could not list tables in $PROD_PROJECT.$ds (no access?)" >> "$orphans_md"
       continue

--- a/tests/test_ci_build.sh
+++ b/tests/test_ci_build.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Tests for scripts/ci_build.sh — verifies models are built with
+# --exclude-resource-type test so a red data test can no longer suppress
+# the diff-gate steps that follow, and that CI_SELECT/CI_DEFER are exported
+# for the downstream (non-blocking) `dbt test` step to consume.
+#
+# Dependency-free: requires bash 4+, coreutils. Stubs `dbt`/`gsutil` on PATH.
+# `set -e` is deliberately NOT used so assertions can accumulate.
+set -uo pipefail
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+SCRIPT="$REPO_ROOT/scripts/ci_build.sh"
+PASS_COUNT=0; FAIL_COUNT=0
+pass(){ echo "    ok   - $1"; PASS_COUNT=$((PASS_COUNT+1)); }
+fail(){ echo "    FAIL - $1"; FAIL_COUNT=$((FAIL_COUNT+1)); }
+assert_contains(){ [[ "$1" == *"$2"* ]] && pass "$3" || fail "$3 (missing '$2')"; }
+
+SANDBOX=$(mktemp -d); mkdir -p "$SANDBOX/bin"
+printf '#!/usr/bin/env bash\necho "dbt $*" >> "$DBT_CALL_LOG"\n' > "$SANDBOX/bin/dbt"
+printf '#!/usr/bin/env bash\nexit 1\n' > "$SANDBOX/bin/gsutil"   # no manifest → full build
+chmod +x "$SANDBOX/bin/dbt" "$SANDBOX/bin/gsutil"
+export DBT_CALL_LOG="$SANDBOX/calls.log"
+
+echo "scenario: model changes, no state → build excludes tests"
+: > "$DBT_CALL_LOG"
+GITHUB_ENV_FILE="$SANDBOX/github_env_1"; : > "$GITHUB_ENV_FILE"
+( cd "$SANDBOX" && env -i PATH="$SANDBOX/bin:/usr/bin:/bin" DBT_CALL_LOG="$DBT_CALL_LOG" \
+    GITHUB_ENV="$GITHUB_ENV_FILE" \
+    HAS_MODEL_CHANGES=true bash "$SCRIPT" >/dev/null 2>&1 )
+assert_contains "$(cat "$DBT_CALL_LOG")" "build --target ci --exclude-resource-type test" "build skips tests"
+assert_contains "$(cat "$GITHUB_ENV_FILE")" "CI_SELECT=" "CI_SELECT exported to GITHUB_ENV"
+assert_contains "$(cat "$GITHUB_ENV_FILE")" "CI_DEFER=" "CI_DEFER exported to GITHUB_ENV"
+
+echo "scenario: model changes, with state → slim build excludes tests and exports select/defer"
+: > "$DBT_CALL_LOG"
+SANDBOX2=$(mktemp -d); mkdir -p "$SANDBOX2/bin"
+printf '#!/usr/bin/env bash\necho "dbt $*" >> "$DBT_CALL_LOG"\ncase "$*" in\n  "ls --select"*) exit 0 ;;\nesac\n' > "$SANDBOX2/bin/dbt"
+printf '#!/usr/bin/env bash\ncase "$1" in\n  ls) exit 0 ;;\n  cp) mkdir -p prod_state; echo "{}" > prod_state/manifest.json; exit 0 ;;\nesac\n' > "$SANDBOX2/bin/gsutil"
+chmod +x "$SANDBOX2/bin/dbt" "$SANDBOX2/bin/gsutil"
+GITHUB_ENV_FILE2="$SANDBOX2/github_env_2"; : > "$GITHUB_ENV_FILE2"
+( cd "$SANDBOX2" && env -i PATH="$SANDBOX2/bin:/usr/bin:/bin" DBT_CALL_LOG="$DBT_CALL_LOG" \
+    GITHUB_ENV="$GITHUB_ENV_FILE2" DBT_ARTIFACTS_BUCKET="fake-bucket" \
+    HAS_MODEL_CHANGES=true bash "$SCRIPT" >/dev/null 2>&1 )
+assert_contains "$(cat "$DBT_CALL_LOG")" "build --target ci --select state:modified+ --defer --state prod_state --exclude-resource-type test" "slim build skips tests"
+assert_contains "$(cat "$GITHUB_ENV_FILE2")" "CI_SELECT=state:modified+" "CI_SELECT exported for slim build"
+assert_contains "$(cat "$GITHUB_ENV_FILE2")" "CI_DEFER=--defer --state prod_state" "CI_DEFER exported for slim build"
+
+echo "results: passed: $PASS_COUNT, failed: $FAIL_COUNT"
+[[ $FAIL_COUNT -eq 0 ]]

--- a/tests/test_ci_build.sh
+++ b/tests/test_ci_build.sh
@@ -14,6 +14,7 @@ PASS_COUNT=0; FAIL_COUNT=0
 pass(){ echo "    ok   - $1"; PASS_COUNT=$((PASS_COUNT+1)); }
 fail(){ echo "    FAIL - $1"; FAIL_COUNT=$((FAIL_COUNT+1)); }
 assert_contains(){ [[ "$1" == *"$2"* ]] && pass "$3" || fail "$3 (missing '$2')"; }
+assert_not_contains(){ [[ "$1" != *"$2"* ]] && pass "$3" || fail "$3 (unexpectedly contains '$2')"; }
 
 SANDBOX=$(mktemp -d); mkdir -p "$SANDBOX/bin"
 printf '#!/usr/bin/env bash\necho "dbt $*" >> "$DBT_CALL_LOG"\n' > "$SANDBOX/bin/dbt"
@@ -44,6 +45,51 @@ GITHUB_ENV_FILE2="$SANDBOX2/github_env_2"; : > "$GITHUB_ENV_FILE2"
 assert_contains "$(cat "$DBT_CALL_LOG")" "build --target ci --select state:modified+ --defer --state prod_state --exclude-resource-type test" "slim build skips tests"
 assert_contains "$(cat "$GITHUB_ENV_FILE2")" "CI_SELECT=state:modified+" "CI_SELECT exported for slim build"
 assert_contains "$(cat "$GITHUB_ENV_FILE2")" "CI_DEFER=--defer --state prod_state" "CI_DEFER exported for slim build"
+
+echo "scenario: HAS_STATE + no fallback + BUILD_SELECT → git-diff scoped build"
+: > "$DBT_CALL_LOG"
+SANDBOX3=$(mktemp -d); mkdir -p "$SANDBOX3/bin"
+printf '#!/usr/bin/env bash\necho "dbt $*" >> "$DBT_CALL_LOG"\n' > "$SANDBOX3/bin/dbt"
+printf '#!/usr/bin/env bash\ncase "$1" in\n  ls) exit 0 ;;\n  cp) mkdir -p prod_state; echo "{}" > prod_state/manifest.json; exit 0 ;;\nesac\n' > "$SANDBOX3/bin/gsutil"
+chmod +x "$SANDBOX3/bin/dbt" "$SANDBOX3/bin/gsutil"
+GITHUB_ENV_FILE3="$SANDBOX3/github_env_3"; : > "$GITHUB_ENV_FILE3"
+( cd "$SANDBOX3" && env -i PATH="$SANDBOX3/bin:/usr/bin:/bin" DBT_CALL_LOG="$DBT_CALL_LOG" \
+    GITHUB_ENV="$GITHUB_ENV_FILE3" DBT_ARTIFACTS_BUCKET="fake-bucket" \
+    HAS_MODEL_CHANGES=true NEEDS_FALLBACK=false BUILD_SELECT="fct_a+" bash "$SCRIPT" >/dev/null 2>&1 )
+assert_contains "$(cat "$DBT_CALL_LOG")" "build --target ci --select fct_a+ --defer --state prod_state --exclude-resource-type test" "git-diff scoped build"
+
+echo "scenario: HAS_STATE + fallback + BUILD_SELECT → combined select"
+: > "$DBT_CALL_LOG"
+SANDBOX4=$(mktemp -d); mkdir -p "$SANDBOX4/bin"
+printf '#!/usr/bin/env bash\necho "dbt $*" >> "$DBT_CALL_LOG"\n' > "$SANDBOX4/bin/dbt"
+printf '#!/usr/bin/env bash\ncase "$1" in\n  ls) exit 0 ;;\n  cp) mkdir -p prod_state; echo "{}" > prod_state/manifest.json; exit 0 ;;\nesac\n' > "$SANDBOX4/bin/gsutil"
+chmod +x "$SANDBOX4/bin/dbt" "$SANDBOX4/bin/gsutil"
+GITHUB_ENV_FILE4="$SANDBOX4/github_env_4"; : > "$GITHUB_ENV_FILE4"
+( cd "$SANDBOX4" && env -i PATH="$SANDBOX4/bin:/usr/bin:/bin" DBT_CALL_LOG="$DBT_CALL_LOG" \
+    GITHUB_ENV="$GITHUB_ENV_FILE4" DBT_ARTIFACTS_BUCKET="fake-bucket" \
+    HAS_MODEL_CHANGES=true NEEDS_FALLBACK=true BUILD_SELECT="fct_a+" bash "$SCRIPT" >/dev/null 2>&1 )
+assert_contains "$(cat "$DBT_CALL_LOG")" "build --target ci --select fct_a+ state:modified+ --defer --state prod_state --exclude-resource-type test" "git-diff + state:modified+ combined select"
+
+echo "scenario: HAS_STATE + fallback + no BUILD_SELECT → state:modified+ only"
+: > "$DBT_CALL_LOG"
+SANDBOX5=$(mktemp -d); mkdir -p "$SANDBOX5/bin"
+printf '#!/usr/bin/env bash\necho "dbt $*" >> "$DBT_CALL_LOG"\n' > "$SANDBOX5/bin/dbt"
+printf '#!/usr/bin/env bash\ncase "$1" in\n  ls) exit 0 ;;\n  cp) mkdir -p prod_state; echo "{}" > prod_state/manifest.json; exit 0 ;;\nesac\n' > "$SANDBOX5/bin/gsutil"
+chmod +x "$SANDBOX5/bin/dbt" "$SANDBOX5/bin/gsutil"
+GITHUB_ENV_FILE5="$SANDBOX5/github_env_5"; : > "$GITHUB_ENV_FILE5"
+( cd "$SANDBOX5" && env -i PATH="$SANDBOX5/bin:/usr/bin:/bin" DBT_CALL_LOG="$DBT_CALL_LOG" \
+    GITHUB_ENV="$GITHUB_ENV_FILE5" DBT_ARTIFACTS_BUCKET="fake-bucket" \
+    HAS_MODEL_CHANGES=true NEEDS_FALLBACK=true BUILD_SELECT="" bash "$SCRIPT" >/dev/null 2>&1 )
+assert_contains "$(cat "$DBT_CALL_LOG")" "build --target ci --select state:modified+ --defer --state prod_state --exclude-resource-type test" "state:modified+ fallback only"
+
+echo "scenario: no manifest (HAS_STATE false) → full build, no defer"
+: > "$DBT_CALL_LOG"
+GITHUB_ENV_FILE6="$SANDBOX/github_env_6"; : > "$GITHUB_ENV_FILE6"
+( cd "$SANDBOX" && env -i PATH="$SANDBOX/bin:/usr/bin:/bin" DBT_CALL_LOG="$DBT_CALL_LOG" \
+    GITHUB_ENV="$GITHUB_ENV_FILE6" DBT_ARTIFACTS_BUCKET="fake-bucket" \
+    HAS_MODEL_CHANGES=true BUILD_SELECT="fct_a+" bash "$SCRIPT" >/dev/null 2>&1 )
+assert_contains "$(cat "$DBT_CALL_LOG")" "build --target ci --exclude-resource-type test" "full build when no manifest"
+assert_not_contains "$(cat "$DBT_CALL_LOG")" "--defer" "no defer when no manifest"
 
 echo "results: passed: $PASS_COUNT, failed: $FAIL_COUNT"
 [[ $FAIL_COUNT -eq 0 ]]

--- a/tests/test_ci_build.sh
+++ b/tests/test_ci_build.sh
@@ -57,6 +57,8 @@ GITHUB_ENV_FILE3="$SANDBOX3/github_env_3"; : > "$GITHUB_ENV_FILE3"
     GITHUB_ENV="$GITHUB_ENV_FILE3" DBT_ARTIFACTS_BUCKET="fake-bucket" \
     HAS_MODEL_CHANGES=true NEEDS_FALLBACK=false BUILD_SELECT="fct_a+" bash "$SCRIPT" >/dev/null 2>&1 )
 assert_contains "$(cat "$DBT_CALL_LOG")" "build --target ci --select fct_a+ --defer --state prod_state --exclude-resource-type test" "git-diff scoped build"
+assert_contains "$(cat "$GITHUB_ENV_FILE3")" "CI_SELECT=fct_a+" "CI_SELECT exported for scoped build"
+assert_contains "$(cat "$GITHUB_ENV_FILE3")" "CI_DEFER=--defer --state prod_state" "CI_DEFER exported for scoped build"
 
 echo "scenario: HAS_STATE + fallback + BUILD_SELECT → combined select"
 : > "$DBT_CALL_LOG"
@@ -69,6 +71,8 @@ GITHUB_ENV_FILE4="$SANDBOX4/github_env_4"; : > "$GITHUB_ENV_FILE4"
     GITHUB_ENV="$GITHUB_ENV_FILE4" DBT_ARTIFACTS_BUCKET="fake-bucket" \
     HAS_MODEL_CHANGES=true NEEDS_FALLBACK=true BUILD_SELECT="fct_a+" bash "$SCRIPT" >/dev/null 2>&1 )
 assert_contains "$(cat "$DBT_CALL_LOG")" "build --target ci --select fct_a+ state:modified+ --defer --state prod_state --exclude-resource-type test" "git-diff + state:modified+ combined select"
+assert_contains "$(cat "$GITHUB_ENV_FILE4")" "CI_SELECT=fct_a+ state:modified+" "CI_SELECT exported for combined build"
+assert_contains "$(cat "$GITHUB_ENV_FILE4")" "CI_DEFER=--defer --state prod_state" "CI_DEFER exported for combined build"
 
 echo "scenario: HAS_STATE + fallback + no BUILD_SELECT → state:modified+ only"
 : > "$DBT_CALL_LOG"
@@ -81,6 +85,8 @@ GITHUB_ENV_FILE5="$SANDBOX5/github_env_5"; : > "$GITHUB_ENV_FILE5"
     GITHUB_ENV="$GITHUB_ENV_FILE5" DBT_ARTIFACTS_BUCKET="fake-bucket" \
     HAS_MODEL_CHANGES=true NEEDS_FALLBACK=true BUILD_SELECT="" bash "$SCRIPT" >/dev/null 2>&1 )
 assert_contains "$(cat "$DBT_CALL_LOG")" "build --target ci --select state:modified+ --defer --state prod_state --exclude-resource-type test" "state:modified+ fallback only"
+assert_contains "$(cat "$GITHUB_ENV_FILE5")" "CI_SELECT=state:modified+" "CI_SELECT exported for state:modified+ fallback"
+assert_contains "$(cat "$GITHUB_ENV_FILE5")" "CI_DEFER=--defer --state prod_state" "CI_DEFER exported for state:modified+ fallback"
 
 echo "scenario: no manifest (HAS_STATE false) → full build, no defer"
 : > "$DBT_CALL_LOG"

--- a/tests/test_get_changed_models.sh
+++ b/tests/test_get_changed_models.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Tests for scripts/get_changed_models.sh change detection + DIFF_SELECT derivation.
+#
+# Dependency-free: requires bash 4+, git, coreutils. No bats, no pip packages.
+# Builds a throwaway git repo per scenario so `git diff --name-only "$BASE_REF...HEAD"`
+# is exercised for real, deterministically, without any network.
+#
+# Usage: bash tests/test_get_changed_models.sh
+#
+# Note: `set -e` is deliberately NOT used. The harness inspects the script's
+# stdout and the $GITHUB_ENV it writes; aborting on a non-zero exit would defeat
+# the purpose.
+set -uo pipefail
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+SCRIPT="$REPO_ROOT/scripts/get_changed_models.sh"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass() { echo "    ok   - $1"; PASS_COUNT=$((PASS_COUNT + 1)); }
+fail() { echo "    FAIL - $1"; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+
+assert_contains() {
+  local haystack=$1 needle=$2 msg=$3
+  if [[ "$haystack" == *"$needle"* ]]; then
+    pass "$msg"
+  else
+    fail "$msg (expected to find '$needle')"
+  fi
+}
+
+assert_not_contains() {
+  local haystack=$1 needle=$2 msg=$3
+  if [[ "$haystack" != *"$needle"* ]]; then
+    pass "$msg"
+  else
+    fail "$msg (did not expect to find '$needle')"
+  fi
+}
+
+# Creates a throwaway git repo with a single base commit and sets:
+#   REPO  - the repo directory (also the cwd used to run the script)
+#   BASE  - the base commit SHA the diff is taken against
+make_repo() {
+  REPO=$(mktemp -d)
+  git -C "$REPO" init -q
+  git -C "$REPO" config user.email "ci@example.com"
+  git -C "$REPO" config user.name "CI Test"
+  git -C "$REPO" config commit.gpgsign false
+  mkdir -p "$REPO/models"
+  echo "# base" > "$REPO/README.md"
+  git -C "$REPO" add README.md
+  git -C "$REPO" commit -q -m "base"
+  BASE=$(git -C "$REPO" rev-parse HEAD)
+}
+
+# Writes each given path (creating parent dirs) with throwaway content and
+# commits the lot as one change on top of the base commit.
+commit_files() {
+  local f
+  for f in "$@"; do
+    mkdir -p "$REPO/$(dirname "$f")"
+    echo "-- changed" > "$REPO/$f"
+    git -C "$REPO" add "$f"
+  done
+  git -C "$REPO" commit -q -m "change"
+}
+
+# Runs the real script inside $REPO with BASE_REF=$1, capturing:
+#   RUN_OUT - stdout+stderr (the human-facing log, incl. the KEY=VALUE echoes)
+#   RUN_ENV - the contents the script wrote to $GITHUB_ENV (exact values)
+run_script() {
+  local base_ref=$1 genv="$REPO/github_env.txt"
+  : > "$genv"
+  RUN_OUT=$(cd "$REPO" && BASE_REF="$base_ref" GITHUB_ENV="$genv" bash "$SCRIPT" 2>&1)
+  RUN_ENV=$(cat "$genv")
+}
+
+cleanup() { [[ -n "${REPO:-}" && -d "$REPO" ]] && rm -rf "$REPO"; }
+
+scenario_1() {
+  echo "  scenario 1: no changed files -> HAS_MODEL_CHANGES=false, DIFF_SELECT empty"
+  make_repo
+  # HEAD == BASE, so the diff is empty.
+  run_script "$BASE"
+  assert_contains "$RUN_OUT" "HAS_MODEL_CHANGES=false" "no changes reports HAS_MODEL_CHANGES=false"
+  # Exact emptiness is only unambiguous in the env file (stdout uses a <none> display fallback).
+  assert_contains "$RUN_ENV" "DIFF_SELECT=" "DIFF_SELECT key is exported"
+  assert_not_contains "$RUN_ENV" "DIFF_SELECT=." "DIFF_SELECT is empty (no value after '=')"
+  assert_not_contains "$RUN_ENV" "+" "no selector tokens are emitted for a no-change diff"
+  cleanup
+}
+
+scenario_2() {
+  echo "  scenario 2: one changed .sql model -> DIFF_SELECT=<name>+"
+  make_repo
+  commit_files "models/staging/stg_foo.sql"
+  run_script "$BASE"
+  assert_contains "$RUN_OUT" "HAS_MODEL_CHANGES=true" "a model change reports HAS_MODEL_CHANGES=true"
+  assert_contains "$RUN_OUT" "DIFF_SELECT=stg_foo+" "stdout advertises the single selector"
+  assert_contains "$RUN_ENV" "DIFF_SELECT=stg_foo+" "env exports exactly one 'name+' token"
+  cleanup
+}
+
+scenario_3() {
+  echo "  scenario 3: multiple changed .sql models -> space-separated 'a+ b+'"
+  make_repo
+  # git diff --name-only sorts by path: marts/ precedes staging/, so the order
+  # is deterministic: fct_b then stg_a.
+  commit_files "models/marts/fct_b.sql" "models/staging/stg_a.sql"
+  run_script "$BASE"
+  assert_contains "$RUN_ENV" "DIFF_SELECT=fct_b+ stg_a+" "both models become space-separated 'name+' tokens"
+  cleanup
+}
+
+scenario_4() {
+  echo "  scenario 4: non-model dbt changes -> HAS_MODEL_CHANGES=true, DIFF_SELECT empty"
+  # A macro change is dbt-relevant (build must run) but yields no model name,
+  # so DIFF_SELECT stays empty and the state:modified+ fallback governs.
+  make_repo
+  commit_files "macros/my_macro.sql"
+  run_script "$BASE"
+  assert_contains "$RUN_OUT" "HAS_MODEL_CHANGES=true" "a macro change still flags model changes"
+  assert_not_contains "$RUN_ENV" "DIFF_SELECT=." "a macro-only change exports an empty DIFF_SELECT"
+  assert_not_contains "$RUN_ENV" "+" "a macro-only change emits no selector tokens"
+  cleanup
+
+  # dbt_project.yml is the same class of change.
+  make_repo
+  commit_files "dbt_project.yml"
+  run_script "$BASE"
+  assert_contains "$RUN_OUT" "HAS_MODEL_CHANGES=true" "a dbt_project.yml change flags model changes"
+  assert_not_contains "$RUN_ENV" "DIFF_SELECT=." "a dbt_project.yml-only change exports an empty DIFF_SELECT"
+  cleanup
+}
+
+echo "test_get_changed_models.sh"
+scenario_1
+scenario_2
+scenario_3
+scenario_4
+
+echo ""
+echo "passed: $PASS_COUNT  failed: $FAIL_COUNT"
+[[ $FAIL_COUNT -eq 0 ]]

--- a/tests/test_get_changed_models.sh
+++ b/tests/test_get_changed_models.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Tests for scripts/get_changed_models.sh change detection + DIFF_SELECT derivation.
+# Tests for scripts/get_changed_models.sh change detection + BUILD_SELECT/DIFF_SELECT/
+# NEEDS_FALLBACK derivation.
 #
 # Dependency-free: requires bash 4+, git, coreutils. No bats, no pip packages.
 # Builds a throwaway git repo per scenario so `git diff --name-only "$BASE_REF...HEAD"`
@@ -80,7 +81,7 @@ run_script() {
 cleanup() { [[ -n "${REPO:-}" && -d "$REPO" ]] && rm -rf "$REPO"; }
 
 scenario_1() {
-  echo "  scenario 1: no changed files -> HAS_MODEL_CHANGES=false, DIFF_SELECT empty"
+  echo "  scenario 1: no changed files -> HAS_MODEL_CHANGES=false, DIFF_SELECT/BUILD_SELECT empty, NEEDS_FALLBACK=false"
   make_repo
   # HEAD == BASE, so the diff is empty.
   run_script "$BASE"
@@ -88,18 +89,24 @@ scenario_1() {
   # Exact emptiness is only unambiguous in the env file (stdout uses a <none> display fallback).
   assert_contains "$RUN_ENV" "DIFF_SELECT=" "DIFF_SELECT key is exported"
   assert_not_contains "$RUN_ENV" "DIFF_SELECT=." "DIFF_SELECT is empty (no value after '=')"
+  assert_contains "$RUN_ENV" "BUILD_SELECT=" "BUILD_SELECT key is exported"
+  assert_not_contains "$RUN_ENV" "BUILD_SELECT=." "BUILD_SELECT is empty (no value after '=')"
   assert_not_contains "$RUN_ENV" "+" "no selector tokens are emitted for a no-change diff"
+  assert_contains "$RUN_OUT" "NEEDS_FALLBACK=false" "no changes reports NEEDS_FALLBACK=false"
   cleanup
 }
 
 scenario_2() {
-  echo "  scenario 2: one changed .sql model -> DIFF_SELECT=<name>+"
+  echo "  scenario 2: one changed .sql model -> BUILD_SELECT=DIFF_SELECT=<name>+, NEEDS_FALLBACK=false"
   make_repo
   commit_files "models/staging/stg_foo.sql"
   run_script "$BASE"
   assert_contains "$RUN_OUT" "HAS_MODEL_CHANGES=true" "a model change reports HAS_MODEL_CHANGES=true"
   assert_contains "$RUN_OUT" "DIFF_SELECT=stg_foo+" "stdout advertises the single selector"
   assert_contains "$RUN_ENV" "DIFF_SELECT=stg_foo+" "env exports exactly one 'name+' token"
+  assert_contains "$RUN_OUT" "BUILD_SELECT=stg_foo+" "stdout advertises BUILD_SELECT matching DIFF_SELECT"
+  assert_contains "$RUN_ENV" "BUILD_SELECT=stg_foo+" "env exports BUILD_SELECT matching DIFF_SELECT"
+  assert_contains "$RUN_OUT" "NEEDS_FALLBACK=false" "a scoped model change reports NEEDS_FALLBACK=false"
   cleanup
 }
 
@@ -111,19 +118,24 @@ scenario_3() {
   commit_files "models/marts/fct_b.sql" "models/staging/stg_a.sql"
   run_script "$BASE"
   assert_contains "$RUN_ENV" "DIFF_SELECT=fct_b+ stg_a+" "both models become space-separated 'name+' tokens"
+  assert_contains "$RUN_ENV" "BUILD_SELECT=fct_b+ stg_a+" "BUILD_SELECT matches DIFF_SELECT for multiple models"
   cleanup
 }
 
 scenario_4() {
-  echo "  scenario 4: non-model dbt changes -> HAS_MODEL_CHANGES=true, DIFF_SELECT empty"
+  echo "  scenario 4: non-model dbt changes -> HAS_MODEL_CHANGES=true, DIFF_SELECT/BUILD_SELECT empty, NEEDS_FALLBACK=true"
   # A macro change is dbt-relevant (build must run) but yields no model name,
-  # so DIFF_SELECT stays empty and the state:modified+ fallback governs.
+  # so DIFF_SELECT/BUILD_SELECT stay empty and NEEDS_FALLBACK signals the caller
+  # to fall back to state:modified+.
   make_repo
   commit_files "macros/my_macro.sql"
   run_script "$BASE"
   assert_contains "$RUN_OUT" "HAS_MODEL_CHANGES=true" "a macro change still flags model changes"
   assert_not_contains "$RUN_ENV" "DIFF_SELECT=." "a macro-only change exports an empty DIFF_SELECT"
   assert_not_contains "$RUN_ENV" "+" "a macro-only change emits no selector tokens"
+  assert_contains "$RUN_OUT" "BUILD_SELECT=" "BUILD_SELECT key is present for a macro-only change"
+  assert_not_contains "$RUN_ENV" "BUILD_SELECT=." "a macro-only change exports an empty BUILD_SELECT"
+  assert_contains "$RUN_OUT" "NEEDS_FALLBACK=true" "a macro-only change reports NEEDS_FALLBACK=true"
   cleanup
 
   # dbt_project.yml is the same class of change.
@@ -132,6 +144,75 @@ scenario_4() {
   run_script "$BASE"
   assert_contains "$RUN_OUT" "HAS_MODEL_CHANGES=true" "a dbt_project.yml change flags model changes"
   assert_not_contains "$RUN_ENV" "DIFF_SELECT=." "a dbt_project.yml-only change exports an empty DIFF_SELECT"
+  assert_contains "$RUN_OUT" "NEEDS_FALLBACK=true" "a dbt_project.yml-only change reports NEEDS_FALLBACK=true"
+  cleanup
+
+  # packages.yml is the same class of change.
+  make_repo
+  commit_files "packages.yml"
+  run_script "$BASE"
+  assert_contains "$RUN_OUT" "HAS_MODEL_CHANGES=true" "a packages.yml change flags model changes"
+  assert_contains "$RUN_OUT" "NEEDS_FALLBACK=true" "a packages.yml-only change reports NEEDS_FALLBACK=true"
+  cleanup
+}
+
+scenario_5() {
+  echo "  scenario 5: seed .csv changed -> BUILD_SELECT/DIFF_SELECT include seed+, NEEDS_FALLBACK=false"
+  make_repo
+  commit_files "seeds/my_seed.csv"
+  run_script "$BASE"
+  assert_contains "$RUN_OUT" "HAS_MODEL_CHANGES=true" "a seed change reports HAS_MODEL_CHANGES=true"
+  assert_contains "$RUN_OUT" "BUILD_SELECT=my_seed+" "stdout advertises the seed selector on BUILD_SELECT"
+  assert_contains "$RUN_OUT" "DIFF_SELECT=my_seed+" "stdout advertises the seed selector on DIFF_SELECT"
+  assert_contains "$RUN_ENV" "BUILD_SELECT=my_seed+" "env exports the seed 'name+' token on BUILD_SELECT"
+  assert_contains "$RUN_OUT" "NEEDS_FALLBACK=false" "a scoped seed change reports NEEDS_FALLBACK=false"
+  cleanup
+}
+
+scenario_6() {
+  echo "  scenario 6: snapshot .sql changed -> BUILD_SELECT/DIFF_SELECT include snap+, NEEDS_FALLBACK=false"
+  make_repo
+  commit_files "snapshots/snap_a.sql"
+  run_script "$BASE"
+  assert_contains "$RUN_OUT" "HAS_MODEL_CHANGES=true" "a snapshot change reports HAS_MODEL_CHANGES=true"
+  assert_contains "$RUN_OUT" "BUILD_SELECT=snap_a+" "stdout advertises the snapshot selector on BUILD_SELECT"
+  assert_contains "$RUN_OUT" "DIFF_SELECT=snap_a+" "stdout advertises the snapshot selector on DIFF_SELECT"
+  assert_contains "$RUN_ENV" "BUILD_SELECT=snap_a+" "env exports the snapshot 'name+' token on BUILD_SELECT"
+  assert_contains "$RUN_OUT" "NEEDS_FALLBACK=false" "a scoped snapshot change reports NEEDS_FALLBACK=false"
+  cleanup
+}
+
+scenario_7() {
+  echo "  scenario 7: models/*.yml-only (no sql/seed/snapshot) -> NEEDS_FALLBACK=true, BUILD_SELECT empty"
+  make_repo
+  commit_files "models/marts/schema.yml"
+  run_script "$BASE"
+  assert_contains "$RUN_OUT" "HAS_MODEL_CHANGES=true" "a models/*.yml change reports HAS_MODEL_CHANGES=true"
+  assert_not_contains "$RUN_ENV" "BUILD_SELECT=." "a models/*.yml-only change exports an empty BUILD_SELECT"
+  assert_contains "$RUN_OUT" "NEEDS_FALLBACK=true" "a models/*.yml-only change (no node) reports NEEDS_FALLBACK=true"
+  cleanup
+}
+
+scenario_8() {
+  echo "  scenario 8: macro + model together -> NEEDS_FALLBACK=true, BUILD_SELECT=<name>+"
+  make_repo
+  commit_files "macros/m.sql" "models/marts/fct_a.sql"
+  run_script "$BASE"
+  assert_contains "$RUN_OUT" "NEEDS_FALLBACK=true" "a macro+model change reports NEEDS_FALLBACK=true"
+  assert_contains "$RUN_OUT" "BUILD_SELECT=fct_a+" "the model is still scoped into BUILD_SELECT despite the macro change"
+  assert_contains "$RUN_OUT" "DIFF_SELECT=fct_a+" "the model is still scoped into DIFF_SELECT despite the macro change"
+  cleanup
+}
+
+scenario_9() {
+  echo "  scenario 9: docs-only (README) change -> HAS_MODEL_CHANGES=false, NEEDS_FALLBACK=false, BUILD_SELECT empty"
+  make_repo
+  commit_files "README.md"
+  run_script "$BASE"
+  assert_contains "$RUN_OUT" "HAS_MODEL_CHANGES=false" "a docs-only change reports HAS_MODEL_CHANGES=false"
+  assert_contains "$RUN_OUT" "NEEDS_FALLBACK=false" "a docs-only change reports NEEDS_FALLBACK=false"
+  assert_not_contains "$RUN_ENV" "BUILD_SELECT=." "a docs-only change exports an empty BUILD_SELECT"
+  assert_not_contains "$RUN_ENV" "DIFF_SELECT=." "a docs-only change exports an empty DIFF_SELECT"
   cleanup
 }
 
@@ -140,6 +221,11 @@ scenario_1
 scenario_2
 scenario_3
 scenario_4
+scenario_5
+scenario_6
+scenario_7
+scenario_8
+scenario_9
 
 echo ""
 echo "passed: $PASS_COUNT  failed: $FAIL_COUNT"

--- a/tests/test_pr_data_diff.sh
+++ b/tests/test_pr_data_diff.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Tests for scripts/pr_data_diff.sh model-selection logic.
+# Dependency-free: bash 4+, coreutils. Stubs dbt/gsutil on PATH. No `set -e`.
+set -uo pipefail
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+SCRIPT="$REPO_ROOT/scripts/pr_data_diff.sh"
+PASS_COUNT=0; FAIL_COUNT=0
+pass() { echo "    ok   - $1"; PASS_COUNT=$((PASS_COUNT + 1)); }
+fail() { echo "    FAIL - $1"; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+assert_contains() { [[ "$1" == *"$2"* ]] && pass "$3" || fail "$3 (missing '$2')"; }
+assert_not_contains() { [[ "$1" != *"$2"* ]] && pass "$3" || fail "$3 (unexpected '$2')"; }
+
+make_sandbox() {
+  SANDBOX=$(mktemp -d); DBT_CALL_LOG="$SANDBOX/dbt_calls.log"; mkdir -p "$SANDBOX/bin"
+  cat > "$SANDBOX/bin/dbt" <<'STUB'
+#!/usr/bin/env bash
+echo "dbt $*" >> "$DBT_CALL_LOG"
+case "$1" in
+  ls) printf '%s\n' model_a model_b ;;
+  run-operation) echo "SUMMARY|table=model_a|dev=1|prod=1|dev_not_in_prod=0|prod_not_in_dev=0" ;;
+  *) : ;;
+esac
+STUB
+  chmod +x "$SANDBOX/bin/dbt"
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$SANDBOX/bin/gsutil"; chmod +x "$SANDBOX/bin/gsutil"
+  export DBT_CALL_LOG
+}
+
+run_case() {  # $1 = extra env assignments; sets RUN_OUT and DBT_CALL_LOG
+  make_sandbox
+  [[ "${WITH_MANIFEST:-0}" == "1" ]] && { mkdir -p "$SANDBOX/prod_state"; echo '{}' > "$SANDBOX/prod_state/manifest.json"; }
+  RUN_OUT=$(cd "$SANDBOX" && env -i PATH="$SANDBOX/bin:/usr/bin:/bin" \
+    DBT_CALL_LOG="$DBT_CALL_LOG" ARTIFACT_DIR="$SANDBOX/diff_reports" \
+    DBT_GCP_PROJECT_CI=ciproj DBT_BQ_DATASET=ci_ds DBT_GCP_PROJECT_PROD=prodproj \
+    $1 bash "$SCRIPT" 2>&1)
+}
+
+echo "scenario 1: docs-only (HAS_MODEL_CHANGES=false) diffs nothing, no dbt ls"
+run_case 'HAS_MODEL_CHANGES=false'
+assert_contains "$RUN_OUT" "No models to diff" "exits early with no models"
+assert_not_contains "$(cat "$DBT_CALL_LOG")" "ls" "never calls dbt ls"
+
+echo "scenario 2: DIFF_SELECT is used verbatim, not state:modified+"
+run_case 'HAS_MODEL_CHANGES=true DIFF_SELECT=fct_example+'
+assert_contains "$(cat "$DBT_CALL_LOG")" "ls --select fct_example+" "selects via DIFF_SELECT"
+assert_not_contains "$(cat "$DBT_CALL_LOG")" "state:modified+" "does not use state fallback"
+
+echo "scenario 3: no DIFF_SELECT, manifest present → state:modified+"
+WITH_MANIFEST=1 run_case 'HAS_MODEL_CHANGES=true'
+assert_contains "$(cat "$DBT_CALL_LOG")" "state:modified+" "uses state comparison when scope absent"
+
+echo "results: passed: $PASS_COUNT, failed: $FAIL_COUNT"
+[[ $FAIL_COUNT -eq 0 ]]

--- a/tests/test_pr_schema_diff.sh
+++ b/tests/test_pr_schema_diff.sh
@@ -101,6 +101,15 @@ echo "$args" >> "$BQ_CALL_LOG"
 DEV_COLS='[{"column_name":"id","ordinal_position":1,"data_type":"INT64","is_nullable":"YES"},{"column_name":"amount","ordinal_position":2,"data_type":"NUMERIC","is_nullable":"YES"}]'
 PROD_COLS='[{"column_name":"id","ordinal_position":1,"data_type":"INT64","is_nullable":"YES"}]'
 
+# col_diff mode: a deliberate, non-trivial difference on fct_example.
+#   added   -> created_at (dev only)
+#   removed -> legacy_flag (prod only)
+#   changed -> amount (NUMERIC in prod, STRING in dev)
+DIFF_DEV_COLS='[{"column_name":"id","ordinal_position":1,"data_type":"INT64","is_nullable":"YES"},{"column_name":"amount","ordinal_position":2,"data_type":"STRING","is_nullable":"YES"},{"column_name":"created_at","ordinal_position":3,"data_type":"TIMESTAMP","is_nullable":"YES"}]'
+DIFF_PROD_COLS='[{"column_name":"id","ordinal_position":1,"data_type":"INT64","is_nullable":"YES"},{"column_name":"amount","ordinal_position":2,"data_type":"NUMERIC","is_nullable":"YES"},{"column_name":"legacy_flag","ordinal_position":3,"data_type":"BOOL","is_nullable":"YES"}]'
+
+is_dev() { [[ "$args" == *ci_pr_1* ]]; }
+
 case "$args" in
   *TABLE_OPTIONS*)
     echo '[]' ;;
@@ -108,16 +117,37 @@ case "$args" in
   *INFORMATION_SCHEMA.COLUMNS*)
     if [[ "$STUB_MODE" == "banner_introspect" ]]; then
       echo 'Welcome to BigQuery! Update available.'
-    elif [[ "$args" == *ci_pr_1* ]]; then
-      echo "$DEV_COLS"
+    elif [[ "$STUB_MODE" == "dev_denied" ]] && is_dev; then
+      # Denial printed on stdout with exit 0: exercises the "Access Denied"
+      # substring branch of the classifier.
+      echo 'BigQuery error in query operation: Access Denied: Dataset ciproj:ci_pr_1'
+    elif [[ "$STUB_MODE" == "prod_denied" ]] && ! is_dev; then
+      # Denial on stderr with exit 1: exercises the empty-output branch.
+      echo 'BigQuery error in query operation: Access Denied: Dataset prodproj:analytics' >&2
+      exit 1
+    elif is_dev; then
+      if [[ "$STUB_MODE" == "col_diff" && "$args" == *"table_name = 'fct_example'"* ]]; then
+        echo "$DIFF_DEV_COLS"
+      else
+        echo "$DEV_COLS"
+      fi
     elif [[ "$args" == *"table_name = 'fct_example'"* ]]; then
-      echo "$PROD_COLS"
+      if [[ "$STUB_MODE" == "col_diff" ]]; then
+        echo "$DIFF_PROD_COLS"
+      else
+        echo "$PROD_COLS"
+      fi
     else
       echo '[]'
     fi ;;
 
   *"INFORMATION_SCHEMA.TABLES WHERE"*)
-    if [[ "$args" == *ci_pr_1* ]]; then
+    if [[ "$STUB_MODE" == "prod_type_denied" ]] && ! is_dev; then
+      # COLUMNS succeeds, TABLES is denied: without classification this used to
+      # surface as NEW_MODEL ("nothing to compare") instead of a failure.
+      echo 'BigQuery error in query operation: Access Denied: Dataset prodproj:analytics' >&2
+      exit 1
+    elif is_dev; then
       echo '[{"table_type":"BASE TABLE"}]'
     elif [[ "$args" == *"table_name = 'fct_example'"* ]]; then
       echo '[{"table_type":"BASE TABLE"}]'
@@ -240,6 +270,118 @@ scenario_6() {
   cleanup
 }
 
+# Returns the SUMMARY| line emitted for one model.
+summary_line_for() { grep -m1 "^SUMMARY|model=$1|" "$SANDBOX/out/$1.txt"; }
+
+# Returns the markdown table row for one model.
+table_row_for() { grep -m1 "^| $1 " "$SANDBOX/out/schema-summary.md"; }
+
+scenario_7() {
+  echo "  scenario 7: the diff actually diffs (Critical: jq -n)"
+  make_sandbox col_diff
+  run_diff; local rc=$?
+  assert_eq 0 "$rc" "exits 0"
+
+  # fct_example: 1 added, 1 removed, 1 type-changed. These are the numbers the
+  # whole report exists to produce; without `jq -n` on compute_column_diff they
+  # come out blank and every assertion below fails.
+  local line row detail
+  line=$(summary_line_for fct_example)
+  row=$(table_row_for fct_example)
+  detail=$(cat "$SANDBOX/out/fct_example.txt")
+
+  assert_contains "$line" "|added=1|removed=1|changed=1|" \
+    "SUMMARY line carries the real column counts"
+  assert_contains "$row" "| 1 | 1 | 1 |" \
+    "markdown table row carries the real column counts"
+  assert_contains "$detail" "Columns added (1):" "added header is populated"
+  assert_contains "$detail" "+ created_at" "names the added column"
+  assert_contains "$detail" "- legacy_flag" "names the removed column"
+  assert_contains "$detail" "* amount: dev=(STRING/YES) prod=(NUMERIC/YES)" \
+    "names the type-changed column with both types"
+  # opt_changes is the last field, so there is no trailing pipe.
+  assert_contains "$line" "|opt_changes=0" "meta diff emits an option-change count"
+
+  # NEW_MODEL rows must carry real counts too, not blanks.
+  assert_contains "$(summary_line_for stg_example)" "|added=2|removed=0|changed=0|" \
+    "NEW_MODEL row reports every dev column as added"
+  cleanup
+}
+
+scenario_8() {
+  echo "  scenario 8: failure rows carry literal 0 counts, never blanks"
+  make_sandbox banner_introspect
+  run_diff
+  assert_contains "$(summary_line_for fct_example)" "|status=NON_JSON|" \
+    "banner output is classified NON_JSON"
+  assert_contains "$(summary_line_for fct_example)" "|added=0|removed=0|changed=0|" \
+    "NON_JSON row carries literal 0 counts"
+  cleanup
+
+  make_sandbox prod_denied
+  run_diff
+  assert_contains "$(summary_line_for fct_example)" "|status=AUTH_ERROR|" \
+    "unreadable prod columns are classified AUTH_ERROR"
+  assert_contains "$(summary_line_for fct_example)" "|added=0|removed=0|changed=0|" \
+    "AUTH_ERROR row carries literal 0 counts"
+  cleanup
+}
+
+scenario_9() {
+  echo "  scenario 9: the ordering invariant holds on every path"
+  # Dev-side denial: previously dev_cols normalized to [] and every prod column
+  # was reported as removed under a clean OK.
+  make_sandbox dev_denied
+  run_diff; local rc=$?
+  assert_eq 0 "$rc" "exits 0 when the dev side is unreadable"
+  local line; line=$(summary_line_for fct_example)
+  assert_contains "$line" "|status=AUTH_ERROR|" "a dev-side denial is classified AUTH_ERROR"
+  assert_not_contains "$line" "|status=OK|" "a dev-side denial is never reported as OK"
+  assert_contains "$line" "|removed=0|" "a dev-side denial does not report phantom removals"
+  cleanup
+
+  # Prod TABLES denial while COLUMNS succeeds: previously downgraded to
+  # NEW_MODEL, i.e. "brand-new model, nothing to compare".
+  make_sandbox prod_type_denied
+  run_diff; rc=$?
+  assert_eq 0 "$rc" "exits 0 when the prod table-type query is denied"
+  local summary; summary=$(cat "$SANDBOX/out/schema-summary.md")
+  assert_contains "$(summary_line_for fct_example)" "|status=AUTH_ERROR|" \
+    "a denied prod table-type query is classified AUTH_ERROR"
+  assert_not_contains "$summary" "NEW_MODEL" \
+    "a permissions failure is never downgraded to NEW_MODEL"
+  cleanup
+}
+
+scenario_10() {
+  echo "  scenario 10: a name collision with a package resolves to one node"
+  make_sandbox ok_no_orphans
+  # Add a same-named model from an installed package, plus the project name.
+  local mf
+  for mf in "$SANDBOX/target/manifest.json" "$SANDBOX/prod_state/manifest.json"; do
+    jq '.metadata = {"project_name": "tpl"}
+        | .nodes["model.tpl.fct_example"].package_name = "tpl"
+        | .nodes["model.tpl.stg_example"].package_name = "tpl"
+        | .nodes["model.some_pkg.fct_example"] = {
+            "resource_type": "model", "name": "fct_example",
+            "alias": "pkg_fct_example", "database": "pkgproj",
+            "schema": "pkg_schema", "package_name": "some_pkg",
+            "unique_id": "model.some_pkg.fct_example"
+          }' "$mf" > "$mf.tmp" && mv "$mf.tmp" "$mf"
+  done
+  run_diff; local rc=$?
+  assert_eq 0 "$rc" "exits 0 on a colliding model name"
+  # The project's own node must win: its alias is fct_example, not the
+  # package's pkg_fct_example, and no query may carry a concatenated name.
+  assert_contains "$(cat "$SANDBOX/out/fct_example.txt")" "Dev:  ciproj.ci_pr_1.fct_example" \
+    "the project's own node wins over the package node"
+  assert_not_contains "$(cat "$BQ_CALL_LOG")" "pkg_fct_example" \
+    "the package node is not queried"
+  local rows; rows=$(grep -c '^| [a-z]' "$SANDBOX/out/schema-summary.md")
+  assert_eq 2 "$rows" "still one summary row per selected model"
+  cleanup
+}
+
 echo "test_pr_schema_diff.sh"
 scenario_1
 scenario_2
@@ -247,6 +389,10 @@ scenario_3
 scenario_4
 scenario_5
 scenario_6
+scenario_7
+scenario_8
+scenario_9
+scenario_10
 
 echo ""
 echo "passed: $PASS_COUNT  failed: $FAIL_COUNT"

--- a/tests/test_pr_schema_diff.sh
+++ b/tests/test_pr_schema_diff.sh
@@ -408,7 +408,7 @@ scenario_10() {
   # package's pkg_fct_example, and no query may carry a concatenated name.
   assert_contains "$(cat "$SANDBOX/out/fct_example.txt")" "Dev:  ciproj.ci_pr_1.fct_example" \
     "the project's own node wins over the package node"
-  assert_not_contains "$(cat "$BQ_CALL_LOG")" "pkg_fct_example" \
+  assert_not_contains "$(cat "$BQ_CALL_LOG")" "pkg_schema" \
     "the package node is not queried"
   local rows; rows=$(grep -c '^| [a-z]' "$SANDBOX/out/schema-summary.md")
   assert_eq 2 "$rows" "still one summary row per selected model"

--- a/tests/test_pr_schema_diff.sh
+++ b/tests/test_pr_schema_diff.sh
@@ -204,11 +204,35 @@ scenario_4() {
   cleanup
 }
 
+scenario_5() {
+  echo "  scenario 5: regression guard — models actually resolve (Defect B)"
+  make_sandbox ok_no_orphans
+  run_diff; local rc=$?
+  assert_eq 0 "$rc" "exits 0"
+
+  # Every model returned by `dbt ls` must produce exactly one summary row and
+  # zero resolution warnings. Models with no prod counterpart satisfy the row
+  # requirement with status NEW_MODEL; the assertion is on row count and
+  # warning absence, not on status value.
+  assert_not_contains "$RUN_STDOUT" "Could not resolve model" \
+    "no model fails to resolve in the PR manifest"
+
+  local summary rows
+  summary=$(cat "$SANDBOX/out/schema-summary.md")
+  rows=$(grep -c '^| [a-z]' <<< "$summary")
+  assert_eq 2 "$rows" "summary table has one row per selected model"
+  assert_contains "$summary" "fct_example" "fct_example appears in the summary"
+  assert_contains "$summary" "stg_example" "stg_example appears in the summary"
+  assert_contains "$summary" "NEW_MODEL" "model with no prod counterpart is NEW_MODEL"
+  cleanup
+}
+
 echo "test_pr_schema_diff.sh"
 scenario_1
 scenario_2
 scenario_3
 scenario_4
+scenario_5
 
 echo ""
 echo "passed: $PASS_COUNT  failed: $FAIL_COUNT"

--- a/tests/test_pr_schema_diff.sh
+++ b/tests/test_pr_schema_diff.sh
@@ -102,11 +102,15 @@ make_sandbox() {
     *)     echo "unknown prod_manifest mode: $prod_manifest" >&2; exit 1 ;;
   esac
 
+  printf 'fct_example\nstg_example\n' > "$SANDBOX/models.txt"
+
   cat > "$SANDBOX/stubs/dbt" <<'STUB'
 #!/usr/bin/env bash
 # Only `dbt ls` is exercised; every other subcommand is a no-op success.
+# The model list lives in models.txt in the sandbox (which is the cwd of the
+# script under test) so a test can extend it without rewriting this stub.
 if [[ "${1:-}" == "ls" ]]; then
-  printf 'fct_example\nstg_example\n'
+  cat models.txt
 fi
 exit 0
 STUB
@@ -115,18 +119,31 @@ STUB
 #!/usr/bin/env bash
 # Stub BigQuery CLI. Records every invocation, then answers based on the
 # shape of the SQL and on STUB_MODE.
+#
+# The script queries WHOLE DATASETS, not single tables, so every fixture below
+# is a dataset-wide result carrying table_name. Narrowing to one table is the
+# script's job; answering per table here would hide a filtering bug.
 args="$*"
 echo "$args" >> "$BQ_CALL_LOG"
 
-DEV_COLS='[{"column_name":"id","ordinal_position":1,"data_type":"INT64","is_nullable":"YES"},{"column_name":"amount","ordinal_position":2,"data_type":"NUMERIC","is_nullable":"YES"}]'
-PROD_COLS='[{"column_name":"id","ordinal_position":1,"data_type":"INT64","is_nullable":"YES"}]'
+DEV_COLS='[{"table_name":"fct_example","column_name":"id","ordinal_position":1,"data_type":"INT64","is_nullable":"YES"},{"table_name":"fct_example","column_name":"amount","ordinal_position":2,"data_type":"NUMERIC","is_nullable":"YES"},{"table_name":"stg_example","column_name":"id","ordinal_position":1,"data_type":"INT64","is_nullable":"YES"},{"table_name":"stg_example","column_name":"amount","ordinal_position":2,"data_type":"NUMERIC","is_nullable":"YES"}]'
+PROD_COLS='[{"table_name":"fct_example","column_name":"id","ordinal_position":1,"data_type":"INT64","is_nullable":"YES"}]'
 
 # col_diff mode: a deliberate, non-trivial difference on fct_example.
 #   added   -> created_at (dev only)
 #   removed -> legacy_flag (prod only)
 #   changed -> amount (NUMERIC in prod, STRING in dev)
-DIFF_DEV_COLS='[{"column_name":"id","ordinal_position":1,"data_type":"INT64","is_nullable":"YES"},{"column_name":"amount","ordinal_position":2,"data_type":"STRING","is_nullable":"YES"},{"column_name":"created_at","ordinal_position":3,"data_type":"TIMESTAMP","is_nullable":"YES"}]'
-DIFF_PROD_COLS='[{"column_name":"id","ordinal_position":1,"data_type":"INT64","is_nullable":"YES"},{"column_name":"amount","ordinal_position":2,"data_type":"NUMERIC","is_nullable":"YES"},{"column_name":"legacy_flag","ordinal_position":3,"data_type":"BOOL","is_nullable":"YES"}]'
+# stg_example keeps its two plain dev columns and has no prod counterpart.
+DIFF_DEV_COLS='[{"table_name":"fct_example","column_name":"id","ordinal_position":1,"data_type":"INT64","is_nullable":"YES"},{"table_name":"fct_example","column_name":"amount","ordinal_position":2,"data_type":"STRING","is_nullable":"YES"},{"table_name":"fct_example","column_name":"created_at","ordinal_position":3,"data_type":"TIMESTAMP","is_nullable":"YES"},{"table_name":"stg_example","column_name":"id","ordinal_position":1,"data_type":"INT64","is_nullable":"YES"},{"table_name":"stg_example","column_name":"amount","ordinal_position":2,"data_type":"NUMERIC","is_nullable":"YES"}]'
+DIFF_PROD_COLS='[{"table_name":"fct_example","column_name":"id","ordinal_position":1,"data_type":"INT64","is_nullable":"YES"},{"table_name":"fct_example","column_name":"amount","ordinal_position":2,"data_type":"NUMERIC","is_nullable":"YES"},{"table_name":"fct_example","column_name":"legacy_flag","ordinal_position":3,"data_type":"BOOL","is_nullable":"YES"}]'
+
+# per_model_cols mode: two models in the SAME dataset with disjoint extra
+# columns. Each must see only its own. Returning the whole dataset's columns —
+# the obvious batching bug — shows up immediately as the other model's column.
+PM_DEV_COLS='[{"table_name":"fct_example","column_name":"id","ordinal_position":1,"data_type":"INT64","is_nullable":"YES"},{"table_name":"fct_example","column_name":"fct_only_col","ordinal_position":2,"data_type":"INT64","is_nullable":"YES"},{"table_name":"stg_example","column_name":"id","ordinal_position":1,"data_type":"INT64","is_nullable":"YES"},{"table_name":"stg_example","column_name":"stg_only_col","ordinal_position":2,"data_type":"STRING","is_nullable":"YES"}]'
+PM_PROD_COLS='[{"table_name":"fct_example","column_name":"id","ordinal_position":1,"data_type":"INT64","is_nullable":"YES"},{"table_name":"stg_example","column_name":"id","ordinal_position":1,"data_type":"INT64","is_nullable":"YES"}]'
+
+BOTH_TABLES='[{"table_name":"fct_example","table_type":"BASE TABLE"},{"table_name":"stg_example","table_type":"BASE TABLE"}]'
 
 is_dev() { [[ "$args" == *ci_pr_1* ]]; }
 
@@ -146,43 +163,39 @@ case "$args" in
       echo 'BigQuery error in query operation: Access Denied: Dataset prodproj:analytics' >&2
       exit 1
     elif is_dev; then
-      if [[ "$STUB_MODE" == "col_diff" && "$args" == *"table_name = 'fct_example'"* ]]; then
-        echo "$DIFF_DEV_COLS"
-      else
-        echo "$DEV_COLS"
-      fi
-    elif [[ "$args" == *"table_name = 'fct_example'"* ]]; then
-      if [[ "$STUB_MODE" == "col_diff" ]]; then
-        echo "$DIFF_PROD_COLS"
-      else
-        echo "$PROD_COLS"
-      fi
+      case "$STUB_MODE" in
+        col_diff)       echo "$DIFF_DEV_COLS" ;;
+        per_model_cols) echo "$PM_DEV_COLS" ;;
+        *)              echo "$DEV_COLS" ;;
+      esac
     else
-      echo '[]'
+      case "$STUB_MODE" in
+        col_diff)       echo "$DIFF_PROD_COLS" ;;
+        per_model_cols) echo "$PM_PROD_COLS" ;;
+        *)              echo "$PROD_COLS" ;;
+      esac
     fi ;;
 
-  *"INFORMATION_SCHEMA.TABLES WHERE"*)
+  *INFORMATION_SCHEMA.TABLES*)
+    # One dataset-wide listing now serves BOTH the batched table-type lookup and
+    # the orphan report: they are byte-identical queries and deliberately share
+    # a cache entry, so there is nothing left to dispatch between.
     if [[ "$STUB_MODE" == "prod_type_denied" ]] && ! is_dev; then
       # COLUMNS succeeds, TABLES is denied: without classification this used to
       # surface as NEW_MODEL ("nothing to compare") instead of a failure.
       echo 'BigQuery error in query operation: Access Denied: Dataset prodproj:analytics' >&2
       exit 1
     elif is_dev; then
-      echo '[{"table_type":"BASE TABLE"}]'
-    elif [[ "$args" == *"table_name = 'fct_example'"* ]]; then
-      echo '[{"table_type":"BASE TABLE"}]'
+      echo "$BOTH_TABLES"
     else
-      echo '[]'
+      case "$STUB_MODE" in
+        denied)         echo 'BigQuery error: Access Denied' >&2; exit 1 ;;
+        has_orphan)     echo '[{"table_name":"legacy_junk","table_type":"BASE TABLE"}]' ;;
+        banner_tables)  echo 'Welcome to BigQuery! Update available.' ;;
+        per_model_cols) echo "$BOTH_TABLES" ;;
+        *)              echo '[{"table_name":"fct_example","table_type":"BASE TABLE"}]' ;;
+      esac
     fi ;;
-
-  *INFORMATION_SCHEMA.TABLES*)
-    # Dataset-wide table listing, used only by the orphan block.
-    case "$STUB_MODE" in
-      denied)        echo 'BigQuery error: Access Denied' >&2; exit 1 ;;
-      has_orphan)    echo '[{"table_name":"legacy_junk","table_type":"BASE TABLE"}]' ;;
-      banner_tables) echo 'Welcome to BigQuery! Update available.' ;;
-      *)             echo '[{"table_name":"fct_example","table_type":"BASE TABLE"}]' ;;
-    esac ;;
 
   *)
     echo '[]' ;;
@@ -487,6 +500,158 @@ scenario_13() {
   cleanup
 }
 
+# Adds $1 extra models, all in the same dev and prod datasets as the fixture
+# pair. Used to prove the query count is a function of dataset count, not of
+# model count.
+add_extra_models() {
+  local n=$1 mf i
+  for mf in "$SANDBOX/target/manifest.json" "$SANDBOX/prod_state/manifest.json"; do
+    [[ -f "$mf" ]] || continue
+    for ((i = 1; i <= n; i++)); do
+      jq --arg id "model.tpl.extra_$i" --arg nm "extra_$i" \
+        '.nodes[$id] = {resource_type: "model", name: $nm, alias: $nm,
+                        database: "prodproj", schema: "analytics",
+                        unique_id: $id}' "$mf" > "$mf.tmp" && mv "$mf.tmp" "$mf"
+    done
+  done
+  for ((i = 1; i <= n; i++)); do
+    echo "extra_$i" >> "$SANDBOX/models.txt"
+  done
+}
+
+bq_call_count() { grep -c . "$BQ_CALL_LOG"; }
+
+scenario_14() {
+  echo "  scenario 14: query volume is per dataset, not per model"
+  # Before batching this loop issued six queries per model plus one dataset
+  # listing: 13 for this two-model fixture, 241 at the real CI selection size of
+  # 40 models, against a step capped at timeout-minutes: 10.
+  #
+  # Two datasets are touched — the CI dataset and prod — at three queries each.
+  # The orphan report's table listing is the same query as the batched one and
+  # shares its cache entry, so it adds nothing.
+  make_sandbox ok_no_orphans
+  run_diff; local rc=$?
+  assert_eq 0 "$rc" "exits 0"
+  local two_model_calls; two_model_calls=$(bq_call_count)
+  assert_eq 6 "$two_model_calls" "two models cost 3 queries per dataset across 2 datasets"
+  assert_eq 2 "$(grep -c 'INFORMATION_SCHEMA.TABLES' "$BQ_CALL_LOG")" \
+    "the orphan listing reuses the batched TABLES query instead of repeating it"
+  cleanup
+
+  # The load-bearing half: the SAME count with six times the models. An
+  # implementation that merely lowered the constant would pass an absolute
+  # threshold and fail here.
+  make_sandbox ok_no_orphans
+  add_extra_models 10
+  run_diff; rc=$?
+  assert_eq 0 "$rc" "exits 0 with twelve models"
+  local rows; rows=$(grep -c '^| [a-z]' "$SANDBOX/out/schema-summary.md")
+  assert_eq 12 "$rows" "all twelve models are actually processed"
+  local twelve_model_calls; twelve_model_calls=$(bq_call_count)
+  assert_eq "$two_model_calls" "$twelve_model_calls" \
+    "query count does not scale with model count"
+  assert_eq 6 "$twelve_model_calls" "twelve models still cost 6 queries"
+  cleanup
+}
+
+scenario_15() {
+  echo "  scenario 15: each model sees only its own columns"
+  # Two models in one dataset with disjoint extra columns. The batching bug this
+  # guards against is handing every model the whole dataset's columns, or the
+  # first table's.
+  make_sandbox per_model_cols
+  run_diff; local rc=$?
+  assert_eq 0 "$rc" "exits 0"
+
+  local fct stg
+  fct=$(cat "$SANDBOX/out/fct_example.txt")
+  stg=$(cat "$SANDBOX/out/stg_example.txt")
+
+  assert_contains "$fct" "+ fct_only_col" "fct_example reports its own added column"
+  assert_not_contains "$fct" "stg_only_col" "fct_example never sees the other table's column"
+  assert_contains "$stg" "+ stg_only_col" "stg_example reports its own added column"
+  assert_not_contains "$stg" "fct_only_col" "stg_example never sees the other table's column"
+
+  assert_contains "$(summary_line_for fct_example)" "|added=1|removed=0|changed=0|" \
+    "fct_example counts only its own column difference"
+  assert_contains "$(summary_line_for stg_example)" "|added=1|removed=0|changed=0|" \
+    "stg_example counts only its own column difference"
+  assert_contains "$(summary_line_for fct_example)" "|status=OK|" \
+    "fct_example is a clean comparison, not NEW_MODEL"
+  assert_contains "$(summary_line_for stg_example)" "|status=OK|" \
+    "stg_example is a clean comparison, not NEW_MODEL"
+  cleanup
+}
+
+scenario_16() {
+  echo "  scenario 16: a dataset-wide failure reaches every model in it"
+  # The blob is fetched once now, so the failure happens once. Every model in
+  # that dataset must still classify exactly as it did when each issued its own
+  # query. Filtering a non-JSON blob instead of passing it through verbatim
+  # would turn a permissions failure into a clean OK diff on every row.
+  make_sandbox prod_denied
+  run_diff; local rc=$?
+  assert_eq 0 "$rc" "exits 0 when the prod dataset fetch is denied"
+  local summary; summary=$(cat "$SANDBOX/out/schema-summary.md")
+  assert_contains "$(summary_line_for fct_example)" "|status=AUTH_ERROR|" \
+    "first model in the denied dataset is AUTH_ERROR"
+  assert_contains "$(summary_line_for stg_example)" "|status=AUTH_ERROR|" \
+    "second model in the denied dataset is AUTH_ERROR too, not OK"
+  assert_not_contains "$summary" "NEW_MODEL" \
+    "no model in a denied dataset is downgraded to NEW_MODEL"
+  assert_not_contains "$summary" "| OK |" \
+    "no model in a denied dataset is downgraded to OK"
+  assert_eq 1 "$(grep -c 'prodproj.analytics..INFORMATION_SCHEMA.COLUMNS' "$BQ_CALL_LOG")" \
+    "the denied fetch is cached, not retried once per model"
+  cleanup
+
+  # Same requirement for a denial printed on stdout with exit 0, which reaches
+  # the classifier as an "Access Denied" substring rather than as emptiness.
+  make_sandbox dev_denied
+  run_diff; rc=$?
+  assert_eq 0 "$rc" "exits 0 when the dev dataset fetch is denied on stdout"
+  assert_contains "$(summary_line_for fct_example)" "|status=AUTH_ERROR|" \
+    "first model sees the Access Denied string"
+  assert_contains "$(summary_line_for stg_example)" "|status=AUTH_ERROR|" \
+    "second model sees the Access Denied string too"
+  cleanup
+
+  # A non-JSON blob that is NOT a denial pins the passthrough precisely: it can
+  # only reach the classifier as NON_JSON if the helper hands it back untouched.
+  # jq-filtering it instead yields empty (which classifies AUTH_ERROR) and
+  # normalizing it first yields [] (which classifies OK) — both wrong, and both
+  # indistinguishable from correct behaviour on a denial alone.
+  make_sandbox banner_introspect
+  run_diff; rc=$?
+  assert_eq 0 "$rc" "exits 0 on a dataset-wide banner"
+  assert_contains "$(summary_line_for fct_example)" "|status=NON_JSON|" \
+    "first model in the dataset sees the banner verbatim"
+  assert_contains "$(summary_line_for stg_example)" "|status=NON_JSON|" \
+    "second model in the dataset sees the banner verbatim, not empty and not []"
+  cleanup
+}
+
+scenario_17() {
+  echo "  scenario 17: dev and prod datasets do not share a cache entry"
+  # A cache keyed on anything less than (project, dataset) would serve the dev
+  # blob for prod, and the diff would silently collapse to zero.
+  make_sandbox ok_no_orphans
+  run_diff; local rc=$?
+  assert_eq 0 "$rc" "exits 0"
+
+  # dev has `amount`, prod does not.
+  assert_contains "$(summary_line_for fct_example)" "|added=1|removed=0|changed=0|" \
+    "the dev/prod difference survives caching"
+  assert_contains "$(cat "$SANDBOX/out/fct_example.txt")" "+ amount" \
+    "the column present only in dev is named"
+  assert_eq 1 "$(grep -c 'ciproj.ci_pr_1..INFORMATION_SCHEMA.COLUMNS' "$BQ_CALL_LOG")" \
+    "the dev dataset is fetched exactly once"
+  assert_eq 1 "$(grep -c 'prodproj.analytics..INFORMATION_SCHEMA.COLUMNS' "$BQ_CALL_LOG")" \
+    "the prod dataset is fetched exactly once, separately"
+  cleanup
+}
+
 echo "test_pr_schema_diff.sh"
 scenario_1
 scenario_2
@@ -501,6 +666,10 @@ scenario_10
 scenario_11
 scenario_12
 scenario_13
+scenario_14
+scenario_15
+scenario_16
+scenario_17
 
 echo ""
 echo "passed: $PASS_COUNT  failed: $FAIL_COUNT"

--- a/tests/test_pr_schema_diff.sh
+++ b/tests/test_pr_schema_diff.sh
@@ -49,8 +49,15 @@ assert_not_contains() {
 # Fixture manifest: two models in prod dataset `analytics`.
 #   fct_example - exists in prod
 #   stg_example - has no prod counterpart, so exercises NEW_MODEL
+#
+# $2 (optional) selects a variant:
+#   base  (default) - as described above
+#   moved           - fct_example lives in a different schema, i.e. the PR has
+#                     relocated it relative to prod. Only `schema` changes so the
+#                     table_name-keyed bq stub still answers for it.
 write_manifest() {
-  cat > "$1" <<'JSON'
+  local path=$1 variant=${2:-base}
+  cat > "$path" <<'JSON'
 {
   "nodes": {
     "model.tpl.fct_example": {
@@ -67,12 +74,20 @@ write_manifest() {
   "sources": {}
 }
 JSON
+  if [[ "$variant" == "moved" ]]; then
+    jq '.nodes["model.tpl.fct_example"].schema = "analytics_legacy"' \
+      "$path" > "$path.tmp" && mv "$path.tmp" "$path"
+  fi
 }
 
 # Builds an isolated sandbox and sets SANDBOX and BQ_CALL_LOG.
 # $1 selects stub behaviour, consumed by the bq stub via STUB_MODE.
+# $2 (optional) selects what prod_state/manifest.json contains:
+#   same  (default) - identical to the PR manifest, so nothing has moved
+#   moved           - prod has fct_example in a different schema
+#   none            - no prod manifest at all, so movement is unknowable
 make_sandbox() {
-  local mode=$1
+  local mode=$1 prod_manifest=${2:-same}
   SANDBOX=$(mktemp -d)
   STUB_MODE=$mode
   BQ_CALL_LOG="$SANDBOX/bq_calls.log"
@@ -80,7 +95,12 @@ make_sandbox() {
   : > "$BQ_CALL_LOG"
 
   write_manifest "$SANDBOX/target/manifest.json"
-  write_manifest "$SANDBOX/prod_state/manifest.json"
+  case "$prod_manifest" in
+    same)  write_manifest "$SANDBOX/prod_state/manifest.json" ;;
+    moved) write_manifest "$SANDBOX/prod_state/manifest.json" moved ;;
+    none)  rmdir "$SANDBOX/prod_state" ;;
+    *)     echo "unknown prod_manifest mode: $prod_manifest" >&2; exit 1 ;;
+  esac
 
   cat > "$SANDBOX/stubs/dbt" <<'STUB'
 #!/usr/bin/env bash
@@ -382,6 +402,91 @@ scenario_10() {
   cleanup
 }
 
+scenario_11() {
+  echo "  scenario 11: movement UNCHANGED (Defect F regression guard)"
+  # PR and prod manifests agree on database/schema/alias, so nothing has moved.
+  # This scenario fails if movement reverts to comparing the physical CI dataset
+  # against prod: those differ by construction and every row comes out MOVED.
+  make_sandbox ok_no_orphans same
+  run_diff; local rc=$?
+  assert_eq 0 "$rc" "exits 0"
+
+  local line row detail
+  line=$(summary_line_for fct_example)
+  row=$(table_row_for fct_example)
+  detail=$(cat "$SANDBOX/out/fct_example.txt")
+
+  assert_contains "$line" "|moved=UNCHANGED|" \
+    "identical manifest locations are UNCHANGED, not MOVED"
+  assert_not_contains "$line" "|moved=MOVED|" \
+    "the ephemeral CI dataset is never mistaken for a move"
+  assert_contains "$row" "| UNCHANGED |" "markdown Moved cell reads UNCHANGED"
+  assert_not_contains "$row" "→" "no movement arrow is rendered when nothing moved"
+  assert_not_contains "$row" "ci_pr_1" "the CI dataset never appears in the Moved cell"
+  assert_contains "$detail" "Movement: UNCHANGED" "detail report states UNCHANGED"
+
+  # Both models sit in the same place in both manifests.
+  assert_contains "$(summary_line_for stg_example)" "|moved=UNCHANGED|" \
+    "a NEW_MODEL relation with an unmoved manifest node is still UNCHANGED"
+
+  # The physical query targets stay visible for debugging, explicitly labelled.
+  assert_contains "$detail" "Physical relations queried:" \
+    "physical query targets are labelled as such"
+  assert_contains "$detail" "Dev:  ciproj.ci_pr_1.fct_example" \
+    "physical dev target is still the CI dataset"
+  cleanup
+}
+
+scenario_12() {
+  echo "  scenario 12: movement MOVED (logical FQNs, not the CI dataset)"
+  # Prod has fct_example in schema `analytics_legacy`; the PR moved it to
+  # `analytics`.
+  make_sandbox ok_no_orphans moved
+  run_diff; local rc=$?
+  assert_eq 0 "$rc" "exits 0"
+
+  local line row detail
+  line=$(summary_line_for fct_example)
+  row=$(table_row_for fct_example)
+  detail=$(cat "$SANDBOX/out/fct_example.txt")
+
+  assert_contains "$line" "|moved=MOVED|" "a changed manifest schema is MOVED"
+  assert_contains "$row" "prodproj.analytics_legacy.fct_example → prodproj.analytics.fct_example" \
+    "the arrow shows prod logical → PR logical"
+  assert_not_contains "$row" "ci_pr_1" "the arrow never shows the CI dataset"
+  assert_contains "$detail" "Movement: prodproj.analytics_legacy.fct_example -> prodproj.analytics.fct_example" \
+    "detail report shows the logical move"
+
+  # The unmoved model in the same run is unaffected.
+  assert_contains "$(summary_line_for stg_example)" "|moved=UNCHANGED|" \
+    "an unmoved model in the same run stays UNCHANGED"
+  cleanup
+}
+
+scenario_13() {
+  echo "  scenario 13: movement UNKNOWN when there is no prod manifest"
+  # Without prod_state/manifest.json the prod FQN is synthesised from the PR's
+  # own identifier. Comparing against it would report a confident UNCHANGED that
+  # was never checked, so movement must be UNKNOWN.
+  make_sandbox ok_no_orphans none
+  run_diff; local rc=$?
+  assert_eq 0 "$rc" "exits 0 with no prod manifest"
+  assert_contains "$RUN_STDOUT" "movement=UNKNOWN" "announces that movement is unknowable"
+
+  local line row
+  line=$(summary_line_for fct_example)
+  row=$(table_row_for fct_example)
+  assert_contains "$line" "|moved=UNKNOWN|" "a synthesised prod FQN yields UNKNOWN"
+  assert_not_contains "$line" "|moved=UNCHANGED|" \
+    "a synthesised prod FQN is never reported as UNCHANGED"
+  assert_not_contains "$line" "|moved=MOVED|" \
+    "a synthesised prod FQN is never reported as MOVED"
+  assert_contains "$row" "| UNKNOWN |" "markdown Moved cell reads UNKNOWN"
+  assert_contains "$(cat "$SANDBOX/out/fct_example.txt")" "<not in prod manifest>" \
+    "detail report says the prod manifest node was not found"
+  cleanup
+}
+
 echo "test_pr_schema_diff.sh"
 scenario_1
 scenario_2
@@ -393,6 +498,9 @@ scenario_7
 scenario_8
 scenario_9
 scenario_10
+scenario_11
+scenario_12
+scenario_13
 
 echo ""
 echo "passed: $PASS_COUNT  failed: $FAIL_COUNT"

--- a/tests/test_pr_schema_diff.sh
+++ b/tests/test_pr_schema_diff.sh
@@ -227,12 +227,26 @@ scenario_5() {
   cleanup
 }
 
+scenario_6() {
+  echo "  scenario 6: bq returns a non-JSON banner for column introspection"
+  make_sandbox banner_introspect
+  run_diff; local rc=$?
+  assert_eq 0 "$rc" "exits 0 when introspection output is unparseable"
+
+  # The requirement is that unparseable output is never reported as a clean
+  # diff. The exact status string is pinned here once observed.
+  local summary; summary=$(cat "$SANDBOX/out/schema-summary.md")
+  assert_contains "$summary" "NON_JSON" "unparseable introspection is marked NON_JSON"
+  cleanup
+}
+
 echo "test_pr_schema_diff.sh"
 scenario_1
 scenario_2
 scenario_3
 scenario_4
 scenario_5
+scenario_6
 
 echo ""
 echo "passed: $PASS_COUNT  failed: $FAIL_COUNT"

--- a/tests/test_pr_schema_diff.sh
+++ b/tests/test_pr_schema_diff.sh
@@ -91,8 +91,10 @@ make_sandbox() {
   SANDBOX=$(mktemp -d)
   STUB_MODE=$mode
   BQ_CALL_LOG="$SANDBOX/bq_calls.log"
+  DBT_CALL_LOG="$SANDBOX/dbt_calls.log"
   mkdir -p "$SANDBOX/stubs" "$SANDBOX/target" "$SANDBOX/prod_state" "$SANDBOX/out"
   : > "$BQ_CALL_LOG"
+  : > "$DBT_CALL_LOG"
 
   write_manifest "$SANDBOX/target/manifest.json"
   case "$prod_manifest" in
@@ -109,6 +111,9 @@ make_sandbox() {
 # Only `dbt ls` is exercised; every other subcommand is a no-op success.
 # The model list lives in models.txt in the sandbox (which is the cwd of the
 # script under test) so a test can extend it without rewriting this stub.
+# Every invocation is logged verbatim so tests can assert on the exact
+# selection args (e.g. --select fct_example+ vs state:modified+).
+echo "dbt $*" >> "$DBT_CALL_LOG"
 if [[ "${1:-}" == "ls" ]]; then
   cat models.txt
 fi
@@ -215,6 +220,9 @@ run_diff() {
     PATH="$SANDBOX/stubs:$PATH" \
     STUB_MODE="$STUB_MODE" \
     BQ_CALL_LOG="$BQ_CALL_LOG" \
+    DBT_CALL_LOG="$DBT_CALL_LOG" \
+    HAS_MODEL_CHANGES="${HAS_MODEL_CHANGES:-true}" \
+    DIFF_SELECT="${DIFF_SELECT:-}" \
     DBT_GCP_PROJECT_CI=ciproj \
     DBT_BQ_DATASET=ci_pr_1 \
     DBT_GCP_PROJECT_PROD=prodproj \
@@ -652,6 +660,29 @@ scenario_17() {
   cleanup
 }
 
+scenario_18() {
+  echo "  scenario 18: docs-only (HAS_MODEL_CHANGES=false) produces no schema diff"
+  make_sandbox ok_no_orphans
+  HAS_MODEL_CHANGES=false run_diff; local rc=$?
+  unset HAS_MODEL_CHANGES
+  assert_eq 0 "$rc" "exits 0 on docs-only PRs"
+  assert_contains "$RUN_STDOUT" "No models" "schema diff exits early on docs-only"
+  assert_not_contains "$(cat "$DBT_CALL_LOG")" "ls" "never calls dbt ls on docs-only PRs"
+  assert_eq 0 "$(grep -c . "$BQ_CALL_LOG")" "never calls bq on docs-only PRs"
+  cleanup
+}
+
+scenario_19() {
+  echo "  scenario 19: DIFF_SELECT is honoured over state:modified+"
+  make_sandbox ok_no_orphans
+  HAS_MODEL_CHANGES=true DIFF_SELECT=fct_example+ run_diff; local rc=$?
+  unset HAS_MODEL_CHANGES DIFF_SELECT
+  assert_eq 0 "$rc" "exits 0"
+  assert_contains "$(cat "$DBT_CALL_LOG")" "ls --select fct_example+" "schema diff uses DIFF_SELECT"
+  assert_not_contains "$(cat "$DBT_CALL_LOG")" "state:modified+" "does not fall back to state:modified+ when DIFF_SELECT is set"
+  cleanup
+}
+
 echo "test_pr_schema_diff.sh"
 scenario_1
 scenario_2
@@ -670,6 +701,8 @@ scenario_14
 scenario_15
 scenario_16
 scenario_17
+scenario_18
+scenario_19
 
 echo ""
 echo "passed: $PASS_COUNT  failed: $FAIL_COUNT"

--- a/tests/test_pr_schema_diff.sh
+++ b/tests/test_pr_schema_diff.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# Tests for scripts/pr_schema_diff.sh
+#
+# Dependency-free: requires bash 4+, jq, coreutils. No bats, no pip packages.
+# Runs the real script against stubbed `bq` and `dbt` binaries on PATH.
+#
+# Usage: bash tests/test_pr_schema_diff.sh
+#
+# Note: `set -e` is deliberately NOT used. The harness inspects non-zero exit
+# codes from the script under test; aborting on them would defeat the purpose.
+set -uo pipefail
+
+REPO_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+SCRIPT="$REPO_ROOT/scripts/pr_schema_diff.sh"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass() { echo "    ok   - $1"; PASS_COUNT=$((PASS_COUNT + 1)); }
+fail() { echo "    FAIL - $1"; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+
+assert_eq() {
+  local expected=$1 actual=$2 msg=$3
+  if [[ "$expected" == "$actual" ]]; then
+    pass "$msg"
+  else
+    fail "$msg (expected '$expected', got '$actual')"
+  fi
+}
+
+assert_contains() {
+  local haystack=$1 needle=$2 msg=$3
+  if [[ "$haystack" == *"$needle"* ]]; then
+    pass "$msg"
+  else
+    fail "$msg (expected to find '$needle')"
+  fi
+}
+
+assert_not_contains() {
+  local haystack=$1 needle=$2 msg=$3
+  if [[ "$haystack" != *"$needle"* ]]; then
+    pass "$msg"
+  else
+    fail "$msg (did not expect to find '$needle')"
+  fi
+}
+
+# Fixture manifest: two models in prod dataset `analytics`.
+#   fct_example - exists in prod
+#   stg_example - has no prod counterpart, so exercises NEW_MODEL
+write_manifest() {
+  cat > "$1" <<'JSON'
+{
+  "nodes": {
+    "model.tpl.fct_example": {
+      "resource_type": "model", "name": "fct_example", "alias": "fct_example",
+      "database": "prodproj", "schema": "analytics",
+      "unique_id": "model.tpl.fct_example"
+    },
+    "model.tpl.stg_example": {
+      "resource_type": "model", "name": "stg_example", "alias": "stg_example",
+      "database": "prodproj", "schema": "analytics",
+      "unique_id": "model.tpl.stg_example"
+    }
+  },
+  "sources": {}
+}
+JSON
+}
+
+# Builds an isolated sandbox and sets SANDBOX and BQ_CALL_LOG.
+# $1 selects stub behaviour, consumed by the bq stub via STUB_MODE.
+make_sandbox() {
+  local mode=$1
+  SANDBOX=$(mktemp -d)
+  STUB_MODE=$mode
+  BQ_CALL_LOG="$SANDBOX/bq_calls.log"
+  mkdir -p "$SANDBOX/stubs" "$SANDBOX/target" "$SANDBOX/prod_state" "$SANDBOX/out"
+  : > "$BQ_CALL_LOG"
+
+  write_manifest "$SANDBOX/target/manifest.json"
+  write_manifest "$SANDBOX/prod_state/manifest.json"
+
+  cat > "$SANDBOX/stubs/dbt" <<'STUB'
+#!/usr/bin/env bash
+# Only `dbt ls` is exercised; every other subcommand is a no-op success.
+if [[ "${1:-}" == "ls" ]]; then
+  printf 'fct_example\nstg_example\n'
+fi
+exit 0
+STUB
+
+  cat > "$SANDBOX/stubs/bq" <<'STUB'
+#!/usr/bin/env bash
+# Stub BigQuery CLI. Records every invocation, then answers based on the
+# shape of the SQL and on STUB_MODE.
+args="$*"
+echo "$args" >> "$BQ_CALL_LOG"
+
+DEV_COLS='[{"column_name":"id","ordinal_position":1,"data_type":"INT64","is_nullable":"YES"},{"column_name":"amount","ordinal_position":2,"data_type":"NUMERIC","is_nullable":"YES"}]'
+PROD_COLS='[{"column_name":"id","ordinal_position":1,"data_type":"INT64","is_nullable":"YES"}]'
+
+case "$args" in
+  *TABLE_OPTIONS*)
+    echo '[]' ;;
+
+  *INFORMATION_SCHEMA.COLUMNS*)
+    if [[ "$STUB_MODE" == "banner_introspect" ]]; then
+      echo 'Welcome to BigQuery! Update available.'
+    elif [[ "$args" == *ci_pr_1* ]]; then
+      echo "$DEV_COLS"
+    elif [[ "$args" == *"table_name = 'fct_example'"* ]]; then
+      echo "$PROD_COLS"
+    else
+      echo '[]'
+    fi ;;
+
+  *"INFORMATION_SCHEMA.TABLES WHERE"*)
+    if [[ "$args" == *ci_pr_1* ]]; then
+      echo '[{"table_type":"BASE TABLE"}]'
+    elif [[ "$args" == *"table_name = 'fct_example'"* ]]; then
+      echo '[{"table_type":"BASE TABLE"}]'
+    else
+      echo '[]'
+    fi ;;
+
+  *INFORMATION_SCHEMA.TABLES*)
+    # Dataset-wide table listing, used only by the orphan block.
+    case "$STUB_MODE" in
+      denied)        echo 'BigQuery error: Access Denied' >&2; exit 1 ;;
+      has_orphan)    echo '[{"table_name":"legacy_junk","table_type":"BASE TABLE"}]' ;;
+      banner_tables) echo 'Welcome to BigQuery! Update available.' ;;
+      *)             echo '[{"table_name":"fct_example","table_type":"BASE TABLE"}]' ;;
+    esac ;;
+
+  *)
+    echo '[]' ;;
+esac
+exit 0
+STUB
+
+  chmod +x "$SANDBOX/stubs/bq" "$SANDBOX/stubs/dbt"
+}
+
+# Runs the script under test inside the sandbox. Returns its exit code and
+# sets RUN_STDOUT / RUN_STDERR. stdin is closed to mimic GitHub Actions.
+run_diff() {
+  local rc
+  RUN_STDOUT=$(
+    cd "$SANDBOX" || exit 99
+    PATH="$SANDBOX/stubs:$PATH" \
+    STUB_MODE="$STUB_MODE" \
+    BQ_CALL_LOG="$BQ_CALL_LOG" \
+    DBT_GCP_PROJECT_CI=ciproj \
+    DBT_BQ_DATASET=ci_pr_1 \
+    DBT_GCP_PROJECT_PROD=prodproj \
+    DBT_BQ_DATASET_PROD=analytics \
+    ARTIFACT_DIR="$SANDBOX/out" \
+      bash "$SCRIPT" 2>"$SANDBOX/stderr.txt" </dev/null
+  )
+  rc=$?
+  RUN_STDERR=$(cat "$SANDBOX/stderr.txt")
+  return $rc
+}
+
+cleanup() { [[ -n "${SANDBOX:-}" && -d "$SANDBOX" ]] && rm -rf "$SANDBOX"; }
+
+scenario_1() {
+  echo "  scenario 1: zero orphans (every prod table covered by the manifest)"
+  make_sandbox ok_no_orphans
+  run_diff; local rc=$?
+  assert_eq 0 "$rc" "exits 0 when no orphans are found"
+  assert_contains "$(cat "$SANDBOX/out/orphans.md")" "Found 0 orphan(s)." "reports zero orphans"
+  cleanup
+}
+
+scenario_2() {
+  echo "  scenario 2: prod dataset unreadable"
+  make_sandbox denied
+  run_diff; local rc=$?
+  assert_eq 0 "$rc" "exits 0 when the prod dataset cannot be listed"
+  assert_contains "$(cat "$SANDBOX/out/orphans.md")" "Could not list tables" \
+    "keeps the unreadable-dataset diagnostic in orphans.md"
+  cleanup
+}
+
+scenario_3() {
+  echo "  scenario 3: an orphan is present"
+  make_sandbox has_orphan
+  run_diff; local rc=$?
+  assert_eq 0 "$rc" "exits 0 when an orphan is found"
+  local report; report=$(cat "$SANDBOX/out/orphans.md")
+  assert_contains "$report" "Found 1 orphan(s)." "counts the orphan"
+  assert_contains "$report" "prodproj.analytics.legacy_junk" "names the orphan"
+  cleanup
+}
+
+scenario_4() {
+  echo "  scenario 4: bq returns a non-JSON banner for the table listing"
+  make_sandbox banner_tables
+  run_diff; local rc=$?
+  assert_eq 0 "$rc" "exits 0 when the table listing is unparseable"
+  cleanup
+}
+
+echo "test_pr_schema_diff.sh"
+scenario_1
+scenario_2
+scenario_3
+scenario_4
+
+echo ""
+echo "passed: $PASS_COUNT  failed: $FAIL_COUNT"
+[[ $FAIL_COUNT -eq 0 ]]


### PR DESCRIPTION
## Summary

Repairs `scripts/pr_schema_diff.sh`, which never actually produced a usable schema diff in CI. Backtested against merged PR #72, the previous implementation posted an empty table for all 37 models and crashed with exit 1. This branch emits 37 populated rows, exits 0, and cuts BigQuery calls from 241 to 6.

Closes #53.

## What was broken

Seven defects were found and fixed:

1. **`set -u` abort (#53)** — an uninitialized `orphans` array aborted the entire CI job.
2. **Empty report** — the diff serialized nothing; added `jq -n` and closed 5 more serialization gaps.
3. **Non-JSON `bq` output** — unguarded `bq` responses (auth banners, access-denied) crashed the jq boundary; now classified and passed through.
4. **Manifest path not passed to jq** in `get_node_by_name`.
5. **False "MOVED" detection** — movement was computed by comparing physical CI dataset locations instead of logical manifest FQNs, flagging every model as moved.
6. **Per-model API storm** — 241 `INFORMATION_SCHEMA` calls; now batched to one query per dataset (6 total), preventing CI timeouts.
7. **Hardening** — shell tests now run in the lint job; the schema-diff CI step is guarded.

## Testing

- `tests/test_pr_schema_diff.sh`: **96/96 assertions passing**.
- Backtested against real PR #72 manifest: 37 populated rows, exit 0, MOVED/UNKNOWN states verified correct.
- Tier 2 validation documented in `docs/superpowers/specs/2026-07-27-tier2-validation-results.md`.

## Scope

Schema diff only. The data-diff scripts (`pr_data_diff.sh`, `compare_template.sql`) are untouched here.

---

## Update — CI diff-accuracy hardening (folded in)

This branch now also carries a follow-on set of fixes so PR diffs are **trustworthy**, validated end-to-end against a real downstream deployment. Added commits (`ecbf488..3bf6dc3`):

1. **Docs-only PRs produce no diff.** `get_changed_models.sh` now emits `DIFF_SELECT` (model+downstream) and self-exports it plus `HAS_MODEL_CHANGES` to `$GITHUB_ENV`; `pr_data_diff.sh` short-circuits when no models changed and otherwise selects `DIFF_SELECT → state:modified+ → all`. Same precedence applied to `pr_schema_diff.sh`.
2. **A red data test no longer suppresses the diff.** `ci_build.sh` builds models with `--exclude-resource-type test` (exporting `CI_SELECT`/`CI_DEFER`); a new non-blocking `dbt test` step runs separately, so the diff/comment steps (still gated on model-build success) no longer get skipped by an unrelated failing test.
3. **Schema-diff parity** with the data diff for the above.

New dependency-free shell harnesses: `test_get_changed_models.sh`, `test_pr_data_diff.sh`, `test_ci_build.sh`, and extended `test_pr_schema_diff.sh` — **127 assertions, all passing**. Design + rationale in `docs/superpowers/plans/2026-08-10-ci-data-diff-accuracy.md`.

Non-blocking follow-ups noted in the plan (deletion/rename under-selection header note; optional parse-only build test).

---

## Update 2 — Build-selection parity (git-diff-scoped build)

Makes the **build** git-diff-scoped so it uses the same selector as the diff (previously the build used `state:modified+` while the diff used git-diff `DIFF_SELECT` — divergent, and manifest-dependent). Added commits `dee59fa..5994c64` (design + plan in `docs/superpowers/`):

- `scripts/get_changed_models.sh` now tracks model/seed/snapshot nodes and emits **`BUILD_SELECT`** (= `DIFF_SELECT`) and **`NEEDS_FALLBACK`**, self-exported to `$GITHUB_ENV`.
- `scripts/ci_build.sh` builds git-diff-scoped: `--select "$BUILD_SELECT" --defer` for model changes; a combined `"$BUILD_SELECT state:modified+"` tier for macro/config changes alongside models; `state:modified+` for macro/config/yaml-only; **full build only when no prod manifest exists**. Build scope now equals diff scope for model-change PRs, and neither depends on the prod manifest for scoping.

Dependency-free shell tests extended: **171 assertions across four suites, all passing**.

**Two intentional behavior changes to note for review/validation:**
1. Dropped the old `dbt ls --select state:modified+` pre-flight → full-build fallback; under `set -e` a state-selection failure now aborts the build instead of degrading. (Git-diff-scoped builds don't touch state, so this only affects the macro/config fallback path with a broken manifest.)
2. A yaml change alongside a *different* model scopes to the model only (the spec's defined "no accompanying node" rule) — a `models/x.yml` configuring model `y` won't pull `y` in unless `y.sql` also changed.

Known limitations (documented in the spec): macro+model PRs build ⊋ diff; the fallback path is still manifest-dependent; no-manifest → full build.
