### PR TITLE
fix(ci): --indirect-selection=cautious on the deferred slim build

### DIFF
--- a/scripts/ci_build.sh
+++ b/scripts/ci_build.sh
@@ -72,7 +72,15 @@ if [[ "${HAS_STATE}" == "true" ]]; then
 
   echo ""
   echo "Starting Slim CI build with defer..."
-  dbt build --target ci --select "state:modified+" --defer --state prod_state
+  # --indirect-selection=cautious: under --defer, unselected models are frozen to
+  # older prod tables. dbt's default eager selection would run any data test that
+  # touches a *selected* model even when the test also touches a *deferred* (stale)
+  # one, comparing a freshly built model against an older prod table — fresh-vs-stale
+  # drift that is not a code change and can fail unrelated PRs. cautious runs a test
+  # only when every model it references is selected; cross-boundary tests are skipped
+  # in PR CI and still run in the full prod build. Single-model schema tests and
+  # both-sides-selected tests are unaffected.
+  dbt build --target ci --select "state:modified+" --defer --state prod_state --indirect-selection cautious
 else
   echo "No production state available, running full build"
   echo "All models will be built from scratch"


### PR DESCRIPTION
## What

One line in `scripts/ci_build.sh` — adds `--indirect-selection cautious` to the slim-CI `dbt build --select state:modified+ --defer --state prod_state` invocation.

## Why

Under `--defer`, unselected models are frozen to the **last prod build's tables** while selected models rebuild **fresh** from live sources. dbt's default **eager** indirect selection then runs *any* data test that references a **selected** model — even when the same test also references a **deferred** (stale) model. That reconciles a freshly built model against an older prod table: **fresh-vs-stale drift that is not a code change**, and it can fail an unrelated PR whose selection happens to span a cross-model test into a deferred node. Because tests run inline in `dbt build` here (blocking), that failure reds CI.

`cautious` runs a data test **only when every model it references is selected**, so these cross-boundary tests are **skipped in PR CI** and still run in full in the nightly/prod build (where everything is built against one consistent snapshot). It cannot mask a real regression: single-model schema tests (`not_null`/`unique`/`accepted_values`) and both-sides-selected tests still run.

## Validated downstream

Reproduced and fixed end-to-end in **weightcare-pipeline-new** (derived from this template): a Facebook-taxonomy PR went red on a cohort-reconciliation test that spanned a rebuilt `orders` and a deferred cohort mart. After this exact flag, the offending test is excluded from selection and CI goes green — confirmed both via `dbt ls --indirect-selection eager|cautious` (deterministic, offline) and a real BigQuery probe build.

## Note for maintainers — reconcile with the in-flight CI overhaul

`main` currently runs tests **inline and blocking** inside `dbt build`, so this flag is the right fix for `main` as it stands. But branch `fix/53-pr-schema-diff-set-u` restructures CI to **split build/test** (`--exclude-resource-type test`) and run `dbt test` as a **separate, non-blocking** step. If that lands, this same flag should move onto that `dbt test` invocation (it needs `--indirect-selection cautious` too — otherwise the non-blocking test *report* still fills with these false errors and buries real ones). Happy to rebase this onto that branch instead if you'd prefer to land them together.

## Not merging
Opening for review per request; leaving the merge decision (and the reconciliation above) to you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)